### PR TITLE
Use keystone public endpoint instead of internal one

### DIFF
--- a/controllers/horizon_controller.go
+++ b/controllers/horizon_controller.go
@@ -442,15 +442,15 @@ func (r *HorizonReconciler) generateServiceConfigMaps(
 	if err != nil {
 		return err
 	}
-	authURL, err := keystoneAPI.GetEndpoint(endpoint.EndpointInternal)
+	keystonePublicURL, err := keystoneAPI.GetEndpoint(endpoint.EndpointPublic)
 	if err != nil {
 		return err
 	}
 
 	templateParameters := map[string]interface{}{
-		"keystoneInternalAuthURL": authURL,
-		"horizonDebug":            instance.Spec.Debug,
-		"horizonSecretKey":        instance.Spec.HorizonSecret,
+		"keystoneURL":      keystonePublicURL,
+		"horizonDebug":     instance.Spec.Debug,
+		"horizonSecretKey": instance.Spec.HorizonSecret,
 	}
 
 	cms := []util.Template{

--- a/templates/horizon/config/local_settings.py
+++ b/templates/horizon/config/local_settings.py
@@ -122,7 +122,7 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 OPENSTACK_HOST = "127.0.0.1"
 #OPENSTACK_KEYSTONE_URL = "http://%s/identity/v3" % OPENSTACK_HOST
 
-OPENSTACK_KEYSTONE_URL = "{{ .keystoneInternalAuthURL }}/v3"
+OPENSTACK_KEYSTONE_URL = "{{ .keystoneURL }}/v3"
 
 # The timezone of the server. This should correspond with the timezone
 # of your entire OpenStack installation, and hopefully be in UTC.


### PR DESCRIPTION
The OPENSTACK_KEYSTONE_URL parameter should point public endpoint because the URL is used by client access for SSO.

Signed-off-by: Takashi Kajinami <tkajinam@redhat.com>