### PR TITLE
Drop secret from spec

### DIFF
--- a/api/v1alpha1/horizon_types.go
+++ b/api/v1alpha1/horizon_types.go
@@ -77,10 +77,6 @@ type HorizonSpec struct {
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default:"HorizonSecretKey"
-	HorizonSecret string `json:"horizonSecret,omitempty"`
-
-	// +kubebuilder:validation:Optional
 	// HorizonRoute holds all of the necessary options for configuring the Horizon Route object.
 	// This can be used to configure TLS
 	//TODO(bshephar) Implement everything about this. It's just a placeholder at the moment.

--- a/config/crd/bases/horizon.openstack.org_horizons.yaml
+++ b/config/crd/bases/horizon.openstack.org_horizons.yaml
@@ -65,8 +65,6 @@ spec:
                   to add additional files. Those get added to the service config dir
                   in /etc/<service> . TODO: -> implement'
                 type: object
-              horizonSecret:
-                type: string
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/config/samples/horizon_v1alpha1_horizon.yaml
+++ b/config/samples/horizon_v1alpha1_horizon.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   replicas: 1
   secret: "osp-secret"
-  horizonSecret: "blahSecret"
   customServiceConfig: |
     [DEFAULT]
     debug = true

--- a/controllers/horizon_controller.go
+++ b/controllers/horizon_controller.go
@@ -42,6 +42,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -465,7 +466,6 @@ func (r *HorizonReconciler) generateServiceConfigMaps(
 	templateParameters := map[string]interface{}{
 		"keystoneURL":        keystonePublicURL,
 		"horizonDebug":       instance.Spec.Debug,
-		"horizonSecretKey":   instance.Spec.HorizonSecret,
 		"horizonEndpointUrl": url,
 	}
 
@@ -531,7 +531,7 @@ func (r *HorizonReconciler) ensureHorizonSecret(
 				Name:       horizon.ServiceName,
 				Namespace:  instance.Namespace,
 				Type:       util.TemplateTypeNone,
-				CustomData: map[string]string{"horizon-secret": instance.Spec.HorizonSecret},
+				CustomData: map[string]string{"horizon-secret": rand.String(10)},
 				Labels:     Labels,
 			},
 		}


### PR DESCRIPTION
The SECRET_KEY parameter is sensitive information and should not be part of spec. Because the value is internal and is not exposed to clients, this makes the value auto-generated without user input.