### PR TITLE
Return error in ConfigMap creation

### DIFF
--- a/controllers/horizon_controller.go
+++ b/controllers/horizon_controller.go
@@ -477,12 +477,7 @@ func (r *HorizonReconciler) generateServiceConfigMaps(
 		},
 	}
 	r.Log.Info(fmt.Sprintf("Creating ConfigMaps with details: %v", cms))
-	err = configmap.EnsureConfigMaps(ctx, h, instance, cms, envVars)
-	if err != nil {
-		return nil
-	}
-
-	return nil
+	return configmap.EnsureConfigMaps(ctx, h, instance, cms, envVars)
 }
 
 // createHashOfInputHashes - creates a hash of hashes which gets added to the resources which requires a restart
@@ -507,7 +502,6 @@ func (r *HorizonReconciler) createHashOfInputHashes(
 	}
 	return hash, changed, nil
 }
-
 
 // ensureHorizonSecret - Creates a k8s secret to hold the Horizon SECRET_KEY.
 func (r *HorizonReconciler) ensureHorizonSecret(


### PR DESCRIPTION
The current logic ignores the error but it should be returned so that the error can be detected in the reconciler.