### PR TITLE
Drop unnecessary lines from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,8 +60,6 @@ ENV USER_UID=$USER_ID \
     OPERATOR_TEMPLATES=/usr/share/horizon-operator/templates/
 
 WORKDIR /
-COPY --from=builder /workspace/manager .
-USER 65532:65532
 
 # Install operator binary to WORKDIR
 COPY --from=builder ${DEST_ROOT}/manager .


### PR DESCRIPTION
/workspace does not exist in the container image and building the image fails with the following error.

```
[2/2] STEP 13/19: COPY --from=builder /workspace/manager .
Error: building at STEP "COPY --from=builder /workspace/manager .": checking on sources under "...": copier: stat: "/workspace/manager": no such file or directory
```

The file should be copied into $DEST_ROOT instead.

Also, user is already twice and the second definition looks redundant.