### PR TITLE
Add missing underscrore in IMAGE_COMPONENT var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ FROM $OPERATOR_BASE_IMAGE
 ARG DEST_ROOT=/dest-root
 ARG USER_ID=65532
 
-ARG IMAGE COMPONENT="horizon-operator-container"
+ARG IMAGE_COMPONENT="horizon-operator-container"
 ARG IMAGE_NAME="horizon-operator"
 ARG IMAGE_VERSION="1.0.0"
 ARG IMAGE_SUMMARY="Horizon Operator"

--- a/config/manifests/bases/horizon-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/horizon-operator.clusterserviceversion.yaml
@@ -1,0 +1,45 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: '[]'
+    capabilities: Basic Install
+  name: horizon-operator.v0.0.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Horizon is the Schema for the horizons API
+      displayName: Horizon
+      kind: Horizon
+      name: horizons.horizon.openstack.org
+      version: v1alpha1
+  description: horizon operator
+  displayName: horizon-operator-bundle
+  icon:
+  - base64data: ""
+    mediatype: ""
+  install:
+    spec:
+      deployments: null
+    strategy: ""
+  installModes:
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - fkjdasf
+  links:
+  - name: Horizon Operator
+    url: https://horizon-operator.domain
+  maturity: alpha
+  provider:
+    name: anything
+    url: fsadfl
+  version: 0.0.0


### PR DESCRIPTION
Container build is failing with:-
~~~
[2/2] STEP 4/19: ARG IMAGE COMPONENT="horizon-operator-container" error building at STEP "ARG IMAGE COMPONENT="horizon-operator-container"": ARG requires exactly one argument definition ~~~

This commit fixed above issue.