### PR TITLE
Support OwnNamespace/SingleNamespace install mode

### DIFF
--- a/config/manifests/bases/horizon-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/horizon-operator.clusterserviceversion.yaml
@@ -25,9 +25,9 @@ spec:
       deployments: null
     strategy: ""
   installModes:
-  - supported: false
+  - supported: true
     type: OwnNamespace
-  - supported: false
+  - supported: true
     type: SingleNamespace
   - supported: false
     type: MultiNamespace


### PR DESCRIPTION
... otherwise OLM can't install horizon-operator when we install the operator by install_yamls.