### PR TITLE
Drop namespace from LeaderElectionID

### DIFF
--- a/main.go
+++ b/main.go
@@ -80,7 +80,7 @@ func main() {
 		Port:                   9443,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "5ad2eba0.github.com/openstack-k8s-operators",
+		LeaderElectionID:       "5ad2eba0.openstack.org",
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly


### PR DESCRIPTION
The LeaderElectionID should not contain '/', which causes an error while acquiring leader lock.