### PR TITLE
Fix api group of deployment resources

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -6,9 +6,9 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
-  - ""
+  - apps
   resources:
-  - configmaps
+  - deployments
   verbs:
   - create
   - get
@@ -19,7 +19,7 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - deployments
+  - configmaps
   verbs:
   - create
   - get

--- a/controllers/horizon_controller.go
+++ b/controllers/horizon_controller.go
@@ -81,7 +81,7 @@ type HorizonReconciler struct {
 //+kubebuilder:rbac:groups=horizon.openstack.org,resources=horizons/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=horizon.openstack.org,resources=horizons/finalizers,verbs=update
 //+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch
-//+kubebuilder:rbac:groups=core,resources=deployments,verbs=get;list;watch;create;update;patch
+//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch
 //+kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete;
 //+kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch;create;update;patch


### PR DESCRIPTION
The deployment resources are part of the apps API group instead of the core API group.