### PR TITLE
Use separate service account for deployment

### DIFF
--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -1,12 +1,55 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  labels:
-    app.kubernetes.io/name: serviceaccount
-    app.kubernetes.io/instance: controller-manager
-    app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: horizon-operator
-    app.kubernetes.io/part-of: horizon-operator
-    app.kubernetes.io/managed-by: kustomize
   name: controller-manager
   namespace: system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: horizon
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: horizon-role
+  namespace: openstack
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - anyuid
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - post
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: horizon-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: horizon-role
+subjects:
+  # Applying the role to both SA (with and without prefix) to be able
+  # to run the operator local
+- kind: ServiceAccount
+  name: horizon-operator-horizon
+  namespace: openstack
+- kind: ServiceAccount
+  name: horizon
+  namespace: openstack

--- a/pkg/horizon/const.go
+++ b/pkg/horizon/const.go
@@ -19,7 +19,7 @@ const (
 	// ServiceName -
 	ServiceName = "horizon"
 	// ServiceAccount -
-	ServiceAccount = "horizon-operator"
+	ServiceAccount = "horizon-operator-horizon"
 	// DatabaseName -
 	DatabaseName = "horizon"
 


### PR DESCRIPTION
... instead of using the operator service account. This follows the current standard in oko.