### PR TITLE
Support custom config

### DIFF
--- a/config/samples/horizon_v1alpha1_horizon.yaml
+++ b/config/samples/horizon_v1alpha1_horizon.yaml
@@ -6,6 +6,4 @@ spec:
   replicas: 1
   secret: "osp-secret"
   customServiceConfig: |
-    [DEFAULT]
-    debug = true
-
+    SESSION_TIMEOUT = 3600

--- a/controllers/horizon_controller.go
+++ b/controllers/horizon_controller.go
@@ -449,7 +449,7 @@ func (r *HorizonReconciler) generateServiceConfigMaps(
 	// custom.conf is going to /etc/<service>/<service>.conf.d
 	// all other files get placed into /etc/<service> to allow overwrite of e.g. logging.conf or policy.json
 	// TODO: make sure custom.conf can not be overwritten
-	customData := map[string]string{common.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig}
+	customData := map[string]string{"9999_custom_settings.py": instance.Spec.CustomServiceConfig}
 	for key, data := range instance.Spec.DefaultConfigOverwrite {
 		customData[key] = data
 	}

--- a/templates/horizon/config/horizon.json
+++ b/templates/horizon/config/horizon.json
@@ -33,6 +33,12 @@
             "dest": "/etc/httpd/conf.d/ssl.conf",
             "merge": false,
             "preserve_properties": true 
+        },
+        {
+            "source": "/var/lib/config-data/merged/9999_custom_settings.py",
+            "dest": "/etc/openstack-dashboard/local_settings.d/9999_custom_settings.py",
+            "merge": false,
+            "preserve_properties": true
         }
     ],
     "permissions": [


### PR DESCRIPTION
Horizon supports loading multiple config files in the local_settings.d directory. This uses that mechanism to allow users to inject/override options.