### PR TITLE
Fix dev branch name in workflow

### DIFF
--- a/.github/workflows/build-horizon-operator.yaml
+++ b/.github/workflows/build-horizon-operator.yaml
@@ -35,8 +35,8 @@ jobs:
       id: branch-name
       uses: tj-actions/branch-names@v5
 
-    - name: Set latest tag for non master branch
-      if: "${{ steps.branch-name.outputs.current_branch != 'master' }}"
+    - name: Set latest tag for non main branch
+      if: "${{ steps.branch-name.outputs.current_branch != 'main' }}"
       run: |
         echo "latesttag=${{ steps.branch-name.outputs.current_branch }}-latest" >> $GITHUB_ENV
 
@@ -109,8 +109,8 @@ jobs:
       id: branch-name
       uses: tj-actions/branch-names@v5
 
-    - name: Set latest tag for non master branch
-      if: "${{ steps.branch-name.outputs.current_branch != 'master' }}"
+    - name: Set latest tag for non main branch
+      if: "${{ steps.branch-name.outputs.current_branch != 'main' }}"
       run: |
         echo "latesttag=${{ steps.branch-name.outputs.current_branch }}-latest" >> $GITHUB_ENV
 
@@ -146,8 +146,8 @@ jobs:
       id: branch-name
       uses: tj-actions/branch-names@v5
 
-    - name: Set latest tag for non master branch
-      if: "${{ steps.branch-name.outputs.current_branch != 'master' }}"
+    - name: Set latest tag for non main branch
+      if: "${{ steps.branch-name.outputs.current_branch != 'main' }}"
       run: |
         echo "latesttag=${{ steps.branch-name.outputs.current_branch }}-latest" >> $GITHUB_ENV
 

--- a/.github/workflows/label-on-pr.yaml
+++ b/.github/workflows/label-on-pr.yaml
@@ -4,7 +4,7 @@ on:
   pull_request_target:
     types: [labeled]
     branches:
-      - 'master'
+      - 'main'
 
 jobs:
   e2e:

--- a/.github/workflows/pull_request_workflow.yml
+++ b/.github/workflows/pull_request_workflow.yml
@@ -1,10 +1,10 @@
 name: Pull Request Workflow
 
-# Run workflow when a new pull request is opened against master branch.
+# Run workflow when a new pull request is opened against main branch.
 on:
   pull_request_target:
     branches:
-    - 'master'
+    - 'main'
 
 jobs:
   check_user_permission:


### PR DESCRIPTION
Currently this repository uses the main branch instead of the master branch as the dev branch. This updates the branch name used in workflow to use the correct branch.