### PR TITLE
Replace TripleO images by TCIB images

### DIFF
--- a/api/v1alpha1/horizon_types.go
+++ b/api/v1alpha1/horizon_types.go
@@ -29,7 +29,7 @@ import (
 // HorizonSpec defines the desired state of Horizon
 type HorizonSpec struct {
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="quay.io/tripleozedcentos9/openstack-horizon:current-tripleo"
+	// +kubebuilder:default="quay.io/podified-zed-centos9/openstack-horizon:current-podified"
 	// horizon Container Image URL
 	ContainerImage string `json:"containerImage"`
 

--- a/config/crd/bases/horizon.openstack.org_horizons.yaml
+++ b/config/crd/bases/horizon.openstack.org_horizons.yaml
@@ -36,7 +36,7 @@ spec:
             description: HorizonSpec defines the desired state of Horizon
             properties:
               containerImage:
-                default: quay.io/tripleozedcentos9/openstack-horizon:current-tripleo
+                default: quay.io/podified-zed-centos9/openstack-horizon:current-podified
                 description: horizon Container Image URL
                 type: string
               customServiceConfig:


### PR DESCRIPTION
We imported container build tools from TripleO as TCIB[1]. Now we are retiring TripleO and should complete the migration.

[1] https://github.com/openstack-k8s-operators/tcib