### PR TITLE
Re-create secret if for any reason it's empty

### DIFF
--- a/controllers/horizon_controller.go
+++ b/controllers/horizon_controller.go
@@ -586,10 +586,10 @@ func (r *HorizonReconciler) ensureHorizonSecret(
 	//
 	// check if secret already exist
 	//
-	_, _, err := oko_secret.GetSecret(ctx, h, horizon.ServiceName, instance.Namespace)
+	scrt, _, err := oko_secret.GetSecret(ctx, h, horizon.ServiceName, instance.Namespace)
 	if err != nil && !k8s_errors.IsNotFound(err) {
 		return err
-	} else if k8s_errors.IsNotFound(err) {
+	} else if k8s_errors.IsNotFound(err) || !validateHorizonSecret(scrt) {
 		r.Log.Info("Creating Horizon Secret")
 		// Create k8s secret to store Horizon Secret
 		tmpl := []util.Template{
@@ -639,4 +639,8 @@ func (r *HorizonReconciler) getMemcachedSvc(ctx context.Context, memcachedName s
 		}
 	}
 	return "", fmt.Errorf("No memcached service was found")
+}
+
+func validateHorizonSecret(secret *corev1.Secret) bool {
+	return len(secret.Data["horizon-secret"]) != 0
 }


### PR DESCRIPTION
If we ever find that the Horizon secret is empty, this change will ensure that the secret is recreated during the reconcile loop. This avoids situations where Horizon will fail to start due to the secret being empty.