### PR TITLE
Remove the -memcached prefix

### DIFF
--- a/controllers/horizon_controller.go
+++ b/controllers/horizon_controller.go
@@ -619,7 +619,7 @@ func (r *HorizonReconciler) renderMemcached(instance *horizonv1alpha1.Horizon) *
 			Kind:       "Memcached",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-memcached", instance.Name),
+			Name:      instance.Name,
 			Namespace: instance.Namespace,
 		},
 	}


### PR DESCRIPTION
When we create a instance of memcached, we no longer need to append it with -memcached. This change removes that and just uses the instance name instead.