### PR TITLE
Use correct golang version in container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-ARG GOLANG_BUILDER=golang:1.20
+ARG GOLANG_BUILDER=golang:1.19
 ARG OPERATOR_BASE_IMAGE=gcr.io/distroless/static:nonroot
 
 FROM $GOLANG_BUILDER as builder


### PR DESCRIPTION
We should use 1.19 instead of 1.20.