### PR TITLE
Fix remaining references to old API version

### DIFF
--- a/tests/kuttl/common/assert-sample-deployment.yaml
+++ b/tests/kuttl/common/assert-sample-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: horizon.openstack.org/v1alpha1
+apiVersion: horizon.openstack.org/v1beta1
 kind: Horizon
 metadata:
   name: horizon

--- a/tests/kuttl/tests/basic-deployment/01-deploy-horizon.yaml
+++ b/tests/kuttl/tests/basic-deployment/01-deploy-horizon.yaml
@@ -2,4 +2,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: |
-      oc apply -n openstack -f ../../../../config/samples/horizon_v1alpha1_horizon.yaml
+      oc apply -n openstack -f ../../../../config/samples/horizon_v1beta1_horizon.yaml


### PR DESCRIPTION
We have bumped API version of this operator from v1alpha to v1beta. This fixes a few remaining references in files for kuttl tests.