### PR TITLE
Fix inconsistent name of Memcached CR

### DIFF
--- a/controllers/horizon_controller.go
+++ b/controllers/horizon_controller.go
@@ -537,7 +537,7 @@ func (r *HorizonReconciler) generateServiceConfigMaps(
 		return err
 	}
 
-	memcachedServerList, err = getMemcachedServerList(ctx, h, instance, fmt.Sprintf("%s-memcached", instance.Name))
+	memcachedServerList, err = getMemcachedServerList(ctx, h, instance, instance.Name)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			horizonv1beta1.HorizonMemcachedReadyCondition,

--- a/controllers/horizon_controller.go
+++ b/controllers/horizon_controller.go
@@ -538,7 +538,7 @@ func (r *HorizonReconciler) generateServiceConfigMaps(
 	}
 
 	memcachedServerList, err = getMemcachedServerList(ctx, h, instance, instance.Name)
-	if err != nil {
+	if (err != nil) || (len(memcachedServerList) == 0) {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			horizonv1beta1.HorizonMemcachedReadyCondition,
 			condition.ErrorReason,


### PR DESCRIPTION
This fixes the inconsistent names of Memcached CR used when creating an instance and getting pod FQDNs, to fix broken cache backend in local_settings.