### PR TITLE
Display status in CLI

### DIFF
--- a/api/v1beta1/horizon_types.go
+++ b/api/v1beta1/horizon_types.go
@@ -141,6 +141,8 @@ type HorizonStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[0].status",description="Status"
+//+kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[0].message",description="Message"
 
 // Horizon is the Schema for the horizons API
 type Horizon struct {

--- a/config/crd/bases/horizon.openstack.org_horizons.yaml
+++ b/config/crd/bases/horizon.openstack.org_horizons.yaml
@@ -15,7 +15,16 @@ spec:
     singular: horizon
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - description: Status
+      jsonPath: .status.conditions[0].status
+      name: Status
+      type: string
+    - description: Message
+      jsonPath: .status.conditions[0].message
+      name: Message
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: Horizon is the Schema for the horizons API


### PR DESCRIPTION
Allows `Ready` condition status to be display at the CLI via `oc get horizon`, similar to what we do for other operators.

This follows what was done for heat-operator by https://github.com/openstack-k8s-operators/heat-operator/pull/138 .