### PR TITLE
Assert Memcached CR in kuttl tests

### DIFF
--- a/tests/kuttl/common/assert-sample-deployment.yaml
+++ b/tests/kuttl/common/assert-sample-deployment.yaml
@@ -9,3 +9,10 @@ spec:
     SESSION_TIMEOUT = 3600
 status:
   readyCount: 1
+---
+apiVersion: memcached.openstack.org/v1beta1
+kind: Memcached
+metadata:
+  name: horizon
+spec:
+  replicas: 1


### PR DESCRIPTION
Horizon controller creates Memcached for caching. This makes sure the CR instance is created.