### PR TITLE
Add memcached suffix for Memcached CR name

### DIFF
--- a/controllers/horizon_controller.go
+++ b/controllers/horizon_controller.go
@@ -352,7 +352,7 @@ func (r *HorizonReconciler) reconcileNormal(ctx context.Context, instance *horiz
 	if instance.Spec.SharedMemcached == "" {
 		memcached := r.renderMemcached(instance)
 		op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), memcached, func() error {
-			memcached.Labels = map[string]string{"service": memcachedName}
+			memcached.Labels = map[string]string{"service": horizon.ServiceName}
 			memcached.Spec.Replicas = instance.Spec.Replicas
 
 			err := controllerutil.SetControllerReference(helper.GetBeforeObject(), memcached, helper.GetScheme())
@@ -607,7 +607,7 @@ func (r *HorizonReconciler) getMemcachedName(
 	if instance.Spec.SharedMemcached != "" {
 		return instance.Spec.SharedMemcached
 	}
-	return instance.Name
+	return fmt.Sprintf("%s-memcached", instance.Name)
 }
 
 // createHashOfInputHashes - creates a hash of hashes which gets added to the resources which requires a restart
@@ -678,7 +678,7 @@ func (r *HorizonReconciler) renderMemcached(instance *horizonv1beta1.Horizon) *m
 			Kind:       "Memcached",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      instance.Name,
+			Name:      fmt.Sprintf("%s-memcached", instance.Name),
 			Namespace: instance.Namespace,
 		},
 	}

--- a/tests/functional/horizon_controller_test.go
+++ b/tests/functional/horizon_controller_test.go
@@ -1,6 +1,7 @@
 package functional
 
 import (
+	"fmt"
 	"os"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -26,7 +27,7 @@ var _ = Describe("Horizon controller", func() {
 			Namespace: namespace,
 		}
 		memcachedName = types.NamespacedName{
-			Name:      horizonName.Name,
+			Name:      fmt.Sprintf("%s-memcached", horizonName.Name),
 			Namespace: horizonName.Namespace,
 		}
 

--- a/tests/kuttl/common/assert-sample-deployment.yaml
+++ b/tests/kuttl/common/assert-sample-deployment.yaml
@@ -13,6 +13,6 @@ status:
 apiVersion: memcached.openstack.org/v1beta1
 kind: Memcached
 metadata:
-  name: horizon
+  name: horizon-memcached
 spec:
   replicas: 1


### PR DESCRIPTION
Some resources created for Memcached CR do not contain prefix/suffix and use instance name. So adding the suffix, following how we create transport url, would be needed to help users identify resources created for Memcached CR.