### PR TITLE
Stop deploying memcached automatically

### DIFF
--- a/api/v1beta1/conditions.go
+++ b/api/v1beta1/conditions.go
@@ -4,14 +4,14 @@ import (
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 )
 
+// Horizon Condition Types used by API objects.
 const (
-	// HorizonMemcachedError - Provides a error that occured during the provisioning of the memcached instance
-	HorizonMemcachedError = "Error creating Memcached instance: %s"
-
-	// HorizonMemcachedReadyCondition - Indicates the Horizon memcached service is ready to be consumed
-	// by Horizon
+	// HorizonMemcachedReadyCondition - Indicates the Horizon memcached service is ready to be consumed by Horizon
 	HorizonMemcachedReadyCondition condition.Type = "HorizonMemcached"
+)
 
+// Horizon Messages used by API objects.
+const (
 	// HorizonMemcachedReadyInitMessage -
 	HorizonMemcachedReadyInitMessage = "Horizon Memcached create not started"
 

--- a/api/v1beta1/horizon_types.go
+++ b/api/v1beta1/horizon_types.go
@@ -86,10 +86,10 @@ type HorizonSpec struct {
 	//TODO(bshephar) Implement everything about this. It's just a placeholder at the moment.
 	Route HorizonRoute `json:"route,omitempty"`
 
-	// +kubebuilder:validation:Optional
-	// SharedMemcahed holds the name of the central memcached instance if it exists. If this value is provided,
-	// then Horizon will use the shared memcached service. Otherwise, we will create one just for Horizon.
-	SharedMemcached string `json:"sharedMemcached,omitempty"`
+	// +kubebuilder:validation:Required
+	// +kubebuilder:default=memcached
+	// Memcached instance name.
+	MemcachedInstance string `json:"memcachedInstance"`
 }
 
 // HorizonDebug can be used to enable debug in the Horizon service

--- a/config/crd/bases/horizon.openstack.org_horizons.yaml
+++ b/config/crd/bases/horizon.openstack.org_horizons.yaml
@@ -73,6 +73,10 @@ spec:
                   to add additional files. Those get added to the service config dir
                   in /etc/<service> . TODO: -> implement'
                 type: object
+              memcachedInstance:
+                default: memcached
+                description: Memcached instance name.
+                type: string
               nodeSelector:
                 additionalProperties:
                   type: string
@@ -169,14 +173,9 @@ spec:
                 description: Secret containing OpenStack password information for
                   Horizon Secret Key
                 type: string
-              sharedMemcached:
-                description: SharedMemcahed holds the name of the central memcached
-                  instance if it exists. If this value is provided, then Horizon will
-                  use the shared memcached service. Otherwise, we will create one
-                  just for Horizon.
-                type: string
             required:
             - containerImage
+            - memcachedInstance
             - secret
             type: object
           status:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -54,13 +54,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  verbs:
-  - get
-  - list
-- apiGroups:
-  - ""
-  resources:
   - secrets
   verbs:
   - create

--- a/tests/kuttl/common/assert-sample-deployment.yaml
+++ b/tests/kuttl/common/assert-sample-deployment.yaml
@@ -9,10 +9,3 @@ spec:
     SESSION_TIMEOUT = 3600
 status:
   readyCount: 1
----
-apiVersion: memcached.openstack.org/v1beta1
-kind: Memcached
-metadata:
-  name: horizon-memcached
-spec:
-  replicas: 1


### PR DESCRIPTION
... but require an pre-deployed instance. This follows the current design to accept mariadb database or rabbitmq.

Depends-on: https://github.com/openstack-k8s-operators/install_yamls/pull/338