### PR TITLE
Fix inconsistent package name for functional tests

### DIFF
--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package functional
+package functional_test
 
 import (
 	"github.com/onsi/gomega"

--- a/tests/functional/horizon_controller_test.go
+++ b/tests/functional/horizon_controller_test.go
@@ -1,4 +1,4 @@
-package functional
+package functional_test
 
 import (
 	"fmt"

--- a/tests/functional/suite_test.go
+++ b/tests/functional/suite_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package functional
+package functional_test
 
 import (
 	"context"


### PR DESCRIPTION
The package name for functional tests is functional_test instead of functional in most of our operators. Let's use the consistent name.