### PR TITLE
Move RBAC config into it's own function

### DIFF
--- a/api/v1beta1/horizon_types.go
+++ b/api/v1beta1/horizon_types.go
@@ -170,7 +170,7 @@ func init() {
 func (instance Horizon) GetEndpoint() (string, error) {
 	url := instance.Status.Endpoint
 	if url == "" {
-		return "", fmt.Errorf("Dashboard url not found")
+		return "", fmt.Errorf("dashboard url not found")
 	}
 	return url, nil
 }


### PR DESCRIPTION
Largely, reconcileNormal() is used to call functions and set status conditions. This change moves the logic for rbac into it's own function and returns the result or error which is more consistent with the rest of the reconcileNormal() tasks.

Additionally, fmt.Errorf strings should be lower case: https://google.github.io/styleguide/go/decisions.html#error-strings