### PR TITLE
Reset Ready condition when update failed

### DIFF
--- a/api/v1beta1/horizon_types.go
+++ b/api/v1beta1/horizon_types.go
@@ -175,10 +175,9 @@ func (instance Horizon) GetEndpoint() (string, error) {
 	return url, nil
 }
 
-// IsReady - Checks for a ReadyCount greater than 1 and returns true or false
+// IsReady - returns true if Horizon is reconciled successfully
 func (instance Horizon) IsReady() bool {
-	// Ready there is at least one Horizon pod running
-	return instance.Status.ReadyCount >= 1
+	return instance.Status.Conditions.IsTrue(condition.ReadyCondition)
 }
 
 // RbacConditionsSet - set the conditions for the rbac object

--- a/controllers/horizon_controller.go
+++ b/controllers/horizon_controller.go
@@ -139,11 +139,18 @@ func (r *HorizonReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 
 	// Always patch the instance status when exiting this function so we can persist any changes.
 	defer func() {
-		// update the overall status condition if service is ready
-		if instance.IsReady() {
-			instance.Status.Conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)
+		// update the Ready condition based on the sub conditions
+		if instance.Status.Conditions.AllSubConditionIsTrue() {
+			instance.Status.Conditions.MarkTrue(
+				condition.ReadyCondition, condition.ReadyMessage)
+		} else {
+			// something is not ready so reset the Ready condition
+			instance.Status.Conditions.MarkUnknown(
+				condition.ReadyCondition, condition.InitReason, condition.ReadyInitMessage)
+			// and recalculate it based on the state of the rest of the conditions
+			instance.Status.Conditions.Set(
+				instance.Status.Conditions.Mirror(condition.ReadyCondition))
 		}
-
 		err := helper.PatchInstance(ctx, instance)
 		if err != nil {
 			_err = err


### PR DESCRIPTION
This ensures the Ready Condition is reset when CR becomes once ready but something fails during reconfiguration.