### PR TITLE
Remove handling for osp-secret

### DIFF
--- a/api/v1beta1/horizon_types.go
+++ b/api/v1beta1/horizon_types.go
@@ -44,10 +44,6 @@ type HorizonSpec struct {
 	// Replicas of horizon API to run
 	Replicas int32 `json:"replicas"`
 
-	// +kubebuilder:validation:Required
-	// Secret containing OpenStack password information for Horizon Secret Key
-	Secret string `json:"secret"`
-
 	// +kubebuilder:validation:Optional
 	// NodeSelector to target subset of worker nodes running this service
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`

--- a/config/crd/bases/horizon.openstack.org_horizons.yaml
+++ b/config/crd/bases/horizon.openstack.org_horizons.yaml
@@ -165,10 +165,6 @@ spec:
                       here to secure the route
                     type: string
                 type: object
-              secret:
-                description: Secret containing OpenStack password information for
-                  Horizon Secret Key
-                type: string
               sharedMemcached:
                 description: SharedMemcahed holds the name of the central memcached
                   instance if it exists. If this value is provided, then Horizon will
@@ -177,7 +173,6 @@ spec:
                 type: string
             required:
             - containerImage
-            - secret
             type: object
           status:
             description: HorizonStatus defines the observed state of Horizon

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -42,7 +42,7 @@ func DefaultHorizonTemplate(name types.NamespacedName) *horizon.Horizon {
 		},
 		Spec: horizon.HorizonSpec{
 			ContainerImage: "test-horizon-container-image",
-			Secret:         SecretName,
+			Replicas:       1,
 		},
 	}
 }

--- a/tests/functional/suite_test.go
+++ b/tests/functional/suite_test.go
@@ -67,8 +67,6 @@ var (
 const (
 	timeout = time.Second * 2
 
-	SecretName = "test-osp-secret"
-
 	interval = time.Millisecond * 200
 )
 


### PR DESCRIPTION
Horizon uses it's own secret to store the SECRET_KEY. This is done outside of the general purpose OSP Secret. This change removes handling for the general osp-secret.