### PR TITLE
Make HorizonMemcachedReadyCondition format more consistent

### DIFF
--- a/api/v1beta1/conditions.go
+++ b/api/v1beta1/conditions.go
@@ -7,7 +7,7 @@ import (
 // Horizon Condition Types used by API objects.
 const (
 	// HorizonMemcachedReadyCondition - Indicates the Horizon memcached service is ready to be consumed by Horizon
-	HorizonMemcachedReadyCondition condition.Type = "HorizonMemcached"
+	HorizonMemcachedReadyCondition condition.Type = "HorizonMemcachedReady"
 )
 
 // Horizon Messages used by API objects.


### PR DESCRIPTION
Most of the conditions have <Service Name><Component>Ready format.