### PR TITLE
Allow overriding Horizon Spec

### DIFF
--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -30,8 +30,8 @@ import (
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 )
 
-func DefaultHorizonTemplate(name types.NamespacedName) *horizon.Horizon {
-	return &horizon.Horizon{
+func CreateHorizon(name types.NamespacedName, spec horizon.HorizonSpec) *horizon.Horizon {
+	instance := &horizon.Horizon{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "horizon.openstack.org/v1alpha1",
 			Kind:       "Horizon",
@@ -40,20 +40,20 @@ func DefaultHorizonTemplate(name types.NamespacedName) *horizon.Horizon {
 			Name:      name.Name,
 			Namespace: name.Namespace,
 		},
-		Spec: horizon.HorizonSpec{
-			ContainerImage:    "test-horizon-container-image",
-			Secret:            SecretName,
-			MemcachedInstance: "memcached",
-		},
+		Spec: spec,
 	}
-}
-
-func CreateHorizon(name types.NamespacedName) *horizon.Horizon {
-	instance := DefaultHorizonTemplate(name)
 	err := k8sClient.Create(ctx, instance)
 	Expect(err).NotTo(HaveOccurred())
 
 	return instance
+}
+
+func GetDefaultHorizonSpec() horizon.HorizonSpec {
+	return horizon.HorizonSpec{
+		ContainerImage:    "test-horizon-container-image",
+		Secret:            SecretName,
+		MemcachedInstance: "memcached",
+	}
 }
 
 func GetHorizon(name types.NamespacedName) *horizon.Horizon {

--- a/tests/functional/horizon_controller_test.go
+++ b/tests/functional/horizon_controller_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Horizon controller", func() {
 
 	When("A Horizon instance is created", func() {
 		BeforeEach(func() {
-			DeferCleanup(DeleteInstance, CreateHorizon(horizonName))
+			DeferCleanup(DeleteInstance, CreateHorizon(horizonName, GetDefaultHorizonSpec()))
 		})
 
 		It("should have the Spec and Status fields initialized", func() {
@@ -65,7 +65,7 @@ var _ = Describe("Horizon controller", func() {
 
 	When("an unrelated secret is provided", func() {
 		BeforeEach(func() {
-			DeferCleanup(DeleteInstance, CreateHorizon(horizonName))
+			DeferCleanup(DeleteInstance, CreateHorizon(horizonName, GetDefaultHorizonSpec()))
 		})
 		It("should remain in a state of waiting for the proper secret", func() {
 			secret = &corev1.Secret{
@@ -87,7 +87,7 @@ var _ = Describe("Horizon controller", func() {
 
 	When("the proper secret is provided", func() {
 		BeforeEach(func() {
-			DeferCleanup(DeleteInstance, CreateHorizon(horizonName))
+			DeferCleanup(DeleteInstance, CreateHorizon(horizonName, GetDefaultHorizonSpec()))
 		})
 		It("should be in a state of having the input ready", func() {
 			secret = &corev1.Secret{
@@ -108,7 +108,7 @@ var _ = Describe("Horizon controller", func() {
 
 	When("using a shared memcached instance", func() {
 		BeforeEach(func() {
-			DeferCleanup(DeleteInstance, CreateHorizon(horizonName))
+			DeferCleanup(DeleteInstance, CreateHorizon(horizonName, GetDefaultHorizonSpec()))
 			DeferCleanup(DeleteInstance, CreateHorizonMemcached())
 			secret = &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
This refactors the functions for creating the Heat instance to allow for the possibility of overriding the default horizon.HorizonSpec