### PR TITLE
Stop rendering Spec.Debug to config file

### DIFF
--- a/config/samples/horizon_v1beta1_horizon.yaml
+++ b/config/samples/horizon_v1beta1_horizon.yaml
@@ -6,4 +6,4 @@ spec:
   replicas: 1
   secret: "osp-secret"
   customServiceConfig: |
-    SESSION_TIMEOUT = 3600
+    DEBUG = True

--- a/controllers/horizon_controller.go
+++ b/controllers/horizon_controller.go
@@ -534,7 +534,6 @@ func (r *HorizonReconciler) generateServiceConfigMaps(
 
 	templateParameters := map[string]interface{}{
 		"keystoneURL":        keystonePublicURL,
-		"horizonDebug":       instance.Spec.Debug,
 		"horizonEndpointUrl": url,
 		"memcachedServers":   fmt.Sprintf("'%s'", memcachedServers),
 	}

--- a/templates/horizon/config/local_settings.py
+++ b/templates/horizon/config/local_settings.py
@@ -36,9 +36,7 @@ HORIZON_CONFIG["password_validator"] = {
 }
 HORIZON_CONFIG["enforce_password_check"] = True
 
-
-DEBUG = "{{ .horizonDebug }}"
-TEMPLATE_DEBUG = DEBUG
+DEBUG = False
 # This setting controls whether or not compression is enabled. Disabling
 # compression makes Horizon considerably slower, but makes it much easier
 # to debug JS and CSS changes

--- a/tests/kuttl/common/assert-sample-deployment.yaml
+++ b/tests/kuttl/common/assert-sample-deployment.yaml
@@ -6,6 +6,6 @@ spec:
   replicas: 1
   secret: "osp-secret"
   customServiceConfig: |
-    SESSION_TIMEOUT = 3600
+    DEBUG = True
 status:
   readyCount: 1


### PR DESCRIPTION
.... because this is meant to control the behavior of pods instead of actual services. Furthermore, this key is not a boolean but a struct. Users can override debug using the customServiceConfig interface.

Also TEMPLATE_DEBUG is deprecated and the behavior is tied to the DEBUG parameter since [1].

[1] https://github.com/openstack/horizon/commit/3488ab3d40f90e9d01598912f7ee398c823f4385