### PR TITLE
Use arbitrary namespace for kuttl tests

### DIFF
--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -16,8 +16,8 @@ apiVersion: kuttl.dev/v1alpha1
 kind: TestSuite
 reportFormat: JSON
 reportName: kuttl-test-horizon
+namespace: horizon-kuttl-tests
 timeout: 180
-namespace: openstack
 parallel: 1
 suppress:
   - events                     # Remove spammy event logs

--- a/tests/kuttl/tests/basic-deployment/01-deploy-horizon.yaml
+++ b/tests/kuttl/tests/basic-deployment/01-deploy-horizon.yaml
@@ -2,4 +2,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: |
-      oc apply -n openstack -f ../../../../config/samples/horizon_v1beta1_horizon.yaml
+      oc apply -n $NAMESPACE -f ../../../../config/samples/horizon_v1beta1_horizon.yaml


### PR DESCRIPTION
... instead of using the openstack namespace which is now globally used.