### PR TITLE
Ensure horizon debug log is enabled

### DIFF
--- a/config/samples/horizon_v1beta1_horizon.yaml
+++ b/config/samples/horizon_v1beta1_horizon.yaml
@@ -7,3 +7,4 @@ spec:
   secret: "osp-secret"
   customServiceConfig: |
     DEBUG = True
+    LOGGING['handlers']['console']['level'] = 'DEBUG'

--- a/tests/kuttl/common/assert-sample-deployment.yaml
+++ b/tests/kuttl/common/assert-sample-deployment.yaml
@@ -7,6 +7,7 @@ spec:
   secret: "osp-secret"
   customServiceConfig: |
     DEBUG = True
+    LOGGING['handlers']['console']['level'] = 'DEBUG'
 status:
   readyCount: 1
 ---


### PR DESCRIPTION
Currently debug log of horizon is not enabled because the log level is determined before DEBUG is overridden.

This adds an additional custom setting so that log level is overridden properly.