### PR TITLE
Remove deprecated settings from local_settings template

### DIFF
--- a/templates/horizon/config/local_settings.py
+++ b/templates/horizon/config/local_settings.py
@@ -14,7 +14,7 @@
 
 import os
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from horizon.utils import secret_key
 

--- a/templates/horizon/config/local_settings.py
+++ b/templates/horizon/config/local_settings.py
@@ -29,7 +29,6 @@ SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 OPENSTACK_API_VERSIONS = {
   'identity': 3,
 }
-HORIZON_CONFIG['default_dashboard'] = 'project'
 HORIZON_CONFIG["password_validator"] = {
     "regex": '',
     "help_text": _(""),


### PR DESCRIPTION
There are a few deprecated settings used in local_settings which are causing warnings.

This remove these so that we can adapt to the major update later more easily.