### PR TITLE
Refactor use of pointer library

### DIFF
--- a/tests/functional/horizon_controller_test.go
+++ b/tests/functional/horizon_controller_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
@@ -31,7 +31,7 @@ var _ = Describe("Horizon controller", func() {
 			Namespace: horizonName.Namespace,
 		}
 		memcachedSpec = memcachedv1.MemcachedSpec{
-			Replicas: pointer.Int32(3),
+			Replicas: ptr.To[int32](3),
 		}
 
 		// lib-common uses OPERATOR_TEMPLATES env var to locate the "templates"


### PR DESCRIPTION
The pointer library[1] has been deprecated and replaced by ptr. This change refactors the usage on the new library[2] and usage.

[1] https://pkg.go.dev/k8s.io/utils/pointer
[2] https://pkg.go.dev/k8s.io/utils/ptr