### PR TITLE
Use internal Keystone service

### DIFF
--- a/controllers/horizon_controller.go
+++ b/controllers/horizon_controller.go
@@ -131,7 +131,6 @@ func (r *HorizonReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		r.Scheme,
 		GetLog(ctx),
 	)
-
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -608,7 +607,8 @@ func (r *HorizonReconciler) generateServiceConfigMaps(
 	if err != nil {
 		return err
 	}
-	keystonePublicURL, err := keystoneAPI.GetEndpoint(endpoint.EndpointPublic)
+
+	authURL, err := keystoneAPI.GetEndpoint(endpoint.EndpointInternal)
 	if err != nil {
 		return err
 	}
@@ -618,7 +618,7 @@ func (r *HorizonReconciler) generateServiceConfigMaps(
 	url := strings.TrimPrefix(instance.Status.Endpoint, "http://")
 
 	templateParameters := map[string]interface{}{
-		"keystoneURL":        keystonePublicURL,
+		"keystoneURL":        authURL,
 		"horizonEndpointUrl": url,
 		"memcachedServers":   fmt.Sprintf("'%s'", memcachedServers),
 	}
@@ -668,7 +668,6 @@ func (r *HorizonReconciler) ensureHorizonSecret(
 	h *helper.Helper,
 	envVars *map[string]env.Setter,
 ) error {
-
 	Labels := labels.GetLabels(instance, labels.GetGroupLabel(horizon.ServiceName), map[string]string{})
 	//
 	// check if secret already exist
@@ -691,7 +690,6 @@ func (r *HorizonReconciler) ensureHorizonSecret(
 		}
 
 		err := oko_secret.EnsureSecrets(ctx, h, instance, tmpl, envVars)
-
 		if err != nil {
 			return err
 		}

--- a/tests/functional/horizon_controller_test.go
+++ b/tests/functional/horizon_controller_test.go
@@ -209,7 +209,7 @@ var _ = Describe("Horizon controller", func() {
 				Name:      horizonName.Name + "-config-data",
 			})
 			Expect(cm.Data["local_settings.py"]).Should(
-				ContainSubstring("OPENSTACK_KEYSTONE_URL = \"http://keystone-public-openstack.testing/v3\""))
+				ContainSubstring("OPENSTACK_KEYSTONE_URL = \"http://keystone-internal.openstack.svc:5000/v3\""))
 			Expect(cm.Data["local_settings.py"]).Should(
 				ContainSubstring("'LOCATION': [ 'memcached-0.memcached:11211', 'memcached-1.memcached:11211', 'memcached-2.memcached:11211' ]"))
 		})


### PR DESCRIPTION
This change swaps the Keystone Public authurl for the internal one. This has been done in the other operators to work around a TLS validation issue with the self-signed certs from cert-manager.