### PR TITLE
Horizon should use internalURL endpoints

### DIFF
--- a/templates/horizon/config/local_settings.py
+++ b/templates/horizon/config/local_settings.py
@@ -26,6 +26,7 @@ LOGIN_URL = '/dashboard/auth/login/'
 LOGOUT_URL = '/dashboard/auth/logout/'
 LOGIN_REDIRECT_URL = '/dashboard/'
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+OPENSTACK_ENDPOINT_TYPE = "internalURL"
 OPENSTACK_API_VERSIONS = {
   'identity': 3,
 }


### PR DESCRIPTION
Horizon currently uses the Public endpoints. This causes issues with the current implementation of self-signed cert-manager Issuer. We ultimately need to resolve this trust issue, but in lieu of an established standard for trusting these certs, we will work around this for now by not relying on the public endpoints.