### PR TITLE
Clear horizon cached data when config changes

### DIFF
--- a/tests/functional/horizon_controller_test.go
+++ b/tests/functional/horizon_controller_test.go
@@ -368,6 +368,12 @@ var _ = Describe("Horizon controller", func() {
 			)
 			Expect(originalHash).NotTo(BeEmpty())
 
+			originalSecret := th.GetSecret(types.NamespacedName{
+				Name:      horizon.ServiceName,
+				Namespace: namespace,
+			})
+			Expect(originalSecret.Data).To(HaveKey("horizon-secret"))
+
 			// Change the content of the CA secret
 			th.UpdateSecret(types.NamespacedName{
 				Name:      CABundleSecretName,
@@ -386,6 +392,12 @@ var _ = Describe("Horizon controller", func() {
 				)
 				g.Expect(newHash).NotTo(BeEmpty())
 				g.Expect(newHash).NotTo(Equal(originalHash))
+				newSecret := th.GetSecret(types.NamespacedName{
+					Name:      horizon.ServiceName,
+					Namespace: namespace,
+				})
+				g.Expect(newSecret.Data).To(HaveKey("horizon-secret"))
+				g.Expect(newSecret.Data["horizon-secret"]).NotTo(Equal(originalSecret.Data["horizon-secret"]))
 			}, timeout, interval).Should(Succeed())
 		})
 	})


### PR DESCRIPTION
The keystone endpoint is cached and may not be valid across config changes. Toggling keystone TLS in particular will change the keystone url and break any existing horizon session.

Jira: [OSPRH-4392](https://issues.redhat.com//browse/OSPRH-4392)