### PR TITLE
Enabled memcached session backend and clear cache when service config…

### DIFF
--- a/templates/horizon/config/local_settings.py
+++ b/templates/horizon/config/local_settings.py
@@ -95,7 +95,9 @@ SECRET_KEY = secret_key.read_from_file(
 CACHES = {
     'default': {
         'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
-        'LOCATION': [ {{.memcachedServers}} ]
+        'LOCATION': [ {{.memcachedServers}} ],
+        # To drop the cached sessions when config changes
+        'KEY_PREFIX': os.environ['CONFIG_HASH']
     },
 }
 
@@ -103,6 +105,7 @@ CACHES = {
 # SESSION_ENGINE to django.contrib.sessions.backends.signed_cookies
 # as shown below:
 #SESSION_ENGINE = 'django.contrib.sessions.backends.signed_cookies'
+SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
 
 
 # Send email to the console by default


### PR DESCRIPTION
… changes

The keystone endpoint is cached and may not be valid across config changes. Toggling keystone TLS in particular will change the keystone url and break any existing horizon session.

This switches from cookie session backend to memcached backend and uses the CONFIG_HASH as the cache prefix to ensure caches are invalidated if/when the config changes.

Jira: [OSPRH-4392](https://issues.redhat.com//browse/OSPRH-4392)