### PR TITLE
Tweak probe timing

### DIFF
--- a/pkg/horizon/deployment.go
+++ b/pkg/horizon/deployment.go
@@ -45,9 +45,9 @@ func Deployment(instance *horizonv1.Horizon, configHash string, labels map[strin
 	}
 
 	livenessProbe := &corev1.Probe{
-		TimeoutSeconds:      15,
-		PeriodSeconds:       5,
-		InitialDelaySeconds: 15,
+		TimeoutSeconds:      5,
+		PeriodSeconds:       10,
+		InitialDelaySeconds: 10,
 		ProbeHandler: corev1.ProbeHandler{
 			HTTPGet: &corev1.HTTPGetAction{
 				Path: "/dashboard/auth/login/?next=/dashboard/",
@@ -56,9 +56,9 @@ func Deployment(instance *horizonv1.Horizon, configHash string, labels map[strin
 		},
 	}
 	readinessProbe := &corev1.Probe{
-		TimeoutSeconds:      25,
-		PeriodSeconds:       5,
-		InitialDelaySeconds: 15,
+		TimeoutSeconds:      5,
+		PeriodSeconds:       10,
+		InitialDelaySeconds: 10,
 		ProbeHandler: corev1.ProbeHandler{
 			HTTPGet: &corev1.HTTPGetAction{
 				Path: "/dashboard/auth/login/?next=/dashboard/",
@@ -68,9 +68,10 @@ func Deployment(instance *horizonv1.Horizon, configHash string, labels map[strin
 	}
 
 	startupProbe := &corev1.Probe{
-		TimeoutSeconds:      30,
-		PeriodSeconds:       60,
-		InitialDelaySeconds: 60,
+		TimeoutSeconds:      5,
+		PeriodSeconds:       10,
+		FailureThreshold:    30,
+		InitialDelaySeconds: 10,
 		ProbeHandler: corev1.ProbeHandler{
 			HTTPGet: &corev1.HTTPGetAction{
 				Path: "/dashboard/auth/login/?next=/dashboard/",


### PR DESCRIPTION
Horizon pods are taking a very long time to go to ready state (when the service will start routing traffic to it).

I can see there are init tasks that run on every container startup but they are not that slow.

The StartupProbe initial delay (60s) seem extremely long. Use a 10s delay instead then poll every 10 seconds for up to 5 mins.

Liveness/readiness probes do not run until StartupProbe succeeds so drop the initial delays to 10s.
Also ensure timeout is less that period to prevent hitting the endpoint with multiple concurrent requests.