### PR TITLE
add kuttl test to check dashboard reachability

### DIFF
--- a/tests/kuttl/common/assert-sample-deployment.yaml
+++ b/tests/kuttl/common/assert-sample-deployment.yaml
@@ -10,3 +10,18 @@ spec:
     LOGGING['handlers']['console']['level'] = 'DEBUG'
 status:
   readyCount: 1
+---
+# Test status code to check dashboard reachability
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+  - script: |
+      set -x
+      RETURN_CODE=0
+      PUBLIC_URL=$(oc get -n $NAMESPACE horizon horizon -o jsonpath='{.status.endpoint}')
+      STATUSCODE=$(curl --silent --output /dev/stderr --head --write-out "%{http_code}" "$PUBLIC_URL/dashboard/auth/login/?next=/dashboard/" -k)
+      if test $STATUSCODE -ne 200; then
+          RETURN_CODE=1
+          echo "${PUBLIC_URL} status code expected is 200 but was ${STATUSCODE}"
+      fi
+      exit $RETURN_CODE


### PR DESCRIPTION
This change adds a Kuttl test assertion to ensure the Horizon route is responding to curl requests with the appropriate HTTP status codes.