### PR TITLE
Set POLICY_FILES_PATH correctly

### DIFF
--- a/templates/horizon/config/local_settings.py
+++ b/templates/horizon/config/local_settings.py
@@ -35,6 +35,7 @@ HORIZON_CONFIG["password_validator"] = {
     "help_text": _(""),
 }
 HORIZON_CONFIG["enforce_password_check"] = True
+POLICY_FILES_PATH = '/etc/openstack-dashboard'
 
 DEBUG = False
 # This setting controls whether or not compression is enabled. Disabling


### PR DESCRIPTION
Since the policy files have all been moved from the app's directory in /usr/share/openstack-dashboard/openstack_dashboard/conf to the config directory at /etc/openstack-dashboard, we have to tell the app where to find them. Without this, all policy checks fail.