### PR TITLE
Set tls_context for django/pymemcache

### DIFF
--- a/controllers/horizon_controller.go
+++ b/controllers/horizon_controller.go
@@ -786,6 +786,7 @@ func (r *HorizonReconciler) generateServiceConfigMaps(
 		"keystoneURL":        authURL,
 		"horizonEndpointUrl": url.Host,
 		"memcachedServers":   mc.GetMemcachedServerListQuotedString(),
+		"memcachedTLS":       mc.GetMemcachedTLSSupport(),
 		"ServerName":         fmt.Sprintf("%s.%s.svc", horizon.ServiceName, instance.Namespace),
 		"Port":               horizon.HorizonPort,
 		"TLS":                false,

--- a/templates/horizon/config/local_settings.py
+++ b/templates/horizon/config/local_settings.py
@@ -13,6 +13,7 @@
 # ----------------------------------------------------------------------
 
 import os
+import ssl
 
 from django.utils.translation import gettext_lazy as _
 
@@ -111,7 +112,12 @@ CACHES = {
         'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
         'LOCATION': [ {{.memcachedServers}} ],
         # To drop the cached sessions when config changes
-        'KEY_PREFIX': os.environ['CONFIG_HASH']
+        'KEY_PREFIX': os.environ['CONFIG_HASH'],
+        'OPTIONS': {
+{{- if .memcachedTLS }}
+            'tls_context': ssl.create_default_context()
+{{- end }}
+        }
     },
 }
 


### PR DESCRIPTION
Pass a default tls context to pymemcache to use the system-wide CA

Related: [OSPRH-5945](https://issues.redhat.com//browse/OSPRH-5945)