### PR TITLE
Set the relevant http headers when Horizon is served as https

### DIFF
--- a/controllers/horizon_controller.go
+++ b/controllers/horizon_controller.go
@@ -785,6 +785,7 @@ func (r *HorizonReconciler) generateServiceConfigMaps(
 		"ServerName":         fmt.Sprintf("%s.%s.svc", horizon.ServiceName, instance.Namespace),
 		"Port":               horizon.HorizonPort,
 		"TLS":                false,
+		"isPublicHTTPS":      url.Scheme == "https",
 	}
 
 	// create httpd tls template parameters

--- a/templates/horizon/config/local_settings.py
+++ b/templates/horizon/config/local_settings.py
@@ -57,17 +57,16 @@ DEBUG = False
 # this to enable liveness checks.
 ALLOWED_HOSTS = ["*", ]
 
-# Set SSL proxy settings:
-# Pass this header from the proxy after terminating the SSL,
-# and don't forget to strip it from the client's request.
-# For more information see:
-# https://docs.djangoproject.com/en/dev/ref/settings/#secure-proxy-ssl-header
-#SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+USE_X_FORWARDED_HOST = True
 
-# If Horizon is being served through SSL, then uncomment the following two
-# settings to better secure the cookies from security exploits
-#CSRF_COOKIE_SECURE = True
-#SESSION_COOKIE_SECURE = True
+{{- if .isPublicHTTPS }}
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+SECURE_SSL_REDIRECT = True
+CSRF_COOKIE_SECURE = True
+SESSION_COOKIE_SECURE = True
+SESSION_COOKIE_HTTPONLY = True
+SECURE_HSTS_SECONDS = 31536000
+{{- end }}
 
 LOCAL_PATH = os.path.dirname(os.path.abspath(__file__))
 


### PR DESCRIPTION
There is a number of headers we can enable in Django configuration that make the site somewhat safer.