### PR TITLE
Enable HSTS on OCP route

### DIFF
--- a/controllers/horizon_controller.go
+++ b/controllers/horizon_controller.go
@@ -365,6 +365,11 @@ func (r *HorizonReconciler) reconcileInit(
 		svcOverride.EmbeddedLabelsAnnotations = &service.EmbeddedLabelsAnnotations{}
 	}
 
+	// Enable HSTS on Route
+	svcOverride.AddAnnotation(map[string]string{
+		"haproxy.router.openshift.io/hsts_header": "max-age=31536000;includeSubDomains;preload",
+	})
+
 	servicePort := corev1.ServicePort{
 		Name:     endpointName,
 		Port:     horizon.HorizonPort,


### PR DESCRIPTION
This change adds the required annotation to the OCP route to enable HSTS headers as per:
https://access.redhat.com/documentation/en-us/openshift_container_platform/4.7/html/networking/configuring-routes\#nw-enabling-hsts_route-configuration