### PR TITLE
Refactor deployment.go code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ginkgo ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" $(GINKGO) --trace --cover --coverpkg=../../pkg/horizon,../../controllers,../../api/v1beta1 --coverprofile cover.out --covermode=atomic ${PROC_CMD} $(GINKGO_ARGS) ./tests/...
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" $(GINKGO) --trace --cover --coverpkg=../../pkg/horizon,../../controllers,../../api/v1beta1 --coverprofile cover.out --covermode=atomic ${PROC_CMD} $(GINKGO_ARGS) ./tests/... ./pkg/horizon/...
 
 ##@ Build
 

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.5.1-0.20250228124213-cd63da392f97
 	github.com/openstack-k8s-operators/lib-common/modules/storage v0.5.1-0.20250228124213-cd63da392f97
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.5.1-0.20250228124213-cd63da392f97
+	github.com/stretchr/testify v1.9.0
 	k8s.io/api v0.29.14
 	k8s.io/apimachinery v0.29.14
 	k8s.io/client-go v0.29.14
@@ -53,6 +54,7 @@ require (
 	github.com/openshift/api v3.9.0+incompatible // indirect
 	github.com/openstack-k8s-operators/lib-common/modules/openstack v0.5.1-0.20250228124213-cd63da392f97 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.19.0 // indirect
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.51.1 // indirect

--- a/pkg/horizon/deployment.go
+++ b/pkg/horizon/deployment.go
@@ -74,12 +74,6 @@ func Deployment(
 	volumes := getVolumes(instance.Name, instance.Spec.ExtraMounts, HorizonPropagation)
 	volumeMounts := getVolumeMounts(instance.Spec.ExtraMounts, HorizonPropagation)
 
-	// add CA cert if defined
-	if instance.Spec.TLS.CaBundleSecretName != "" {
-		volumes = append(volumes, instance.Spec.TLS.CreateVolume())
-		volumeMounts = append(volumeMounts, instance.Spec.TLS.CreateVolumeMounts(nil)...)
-	}
-
 	if instance.Spec.TLS.Enabled() {
 		tlsRequiredOptions := TLSRequiredOptions{
 			&containerPort,
@@ -204,6 +198,12 @@ func (t *TLSRequiredOptions) formatTLSOptions(instance *horizonv1.Horizon) error
 	svc, err = instance.Spec.TLS.GenericService.ToService()
 	if err != nil {
 		return err
+	}
+
+	// add CA cert if defined
+	if instance.Spec.TLS.CaBundleSecretName != "" {
+		t.volumes = append(t.volumes, instance.Spec.TLS.CreateVolume())
+		t.volumeMounts = append(t.volumeMounts, instance.Spec.TLS.CreateVolumeMounts(nil)...)
 	}
 
 	t.containerPort.ContainerPort = HorizonPortTLS

--- a/pkg/horizon/deployment.go
+++ b/pkg/horizon/deployment.go
@@ -21,6 +21,7 @@ import (
 	common "github.com/openstack-k8s-operators/lib-common/modules/common"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/affinity"
 	env "github.com/openstack-k8s-operators/lib-common/modules/common/env"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/tls"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -34,6 +35,15 @@ const (
 	horizonDashboardURL      = "/dashboard/auth/login/?next=/dashboard/"
 	horizonContainerPortName = "horizon"
 )
+
+type TLSRequiredOptions struct {
+	containerPort  *corev1.ContainerPort
+	livenessProbe  *corev1.Probe
+	readinessProbe *corev1.Probe
+	startupProbe   *corev1.Probe
+	volumes        []corev1.Volume
+	volumeMounts   []corev1.VolumeMount
+}
 
 // Deployment creates the k8s deployment structure required to run Horizon
 func Deployment(
@@ -54,15 +64,11 @@ func Deployment(
 		ContainerPort: HorizonPort,
 	}
 
-	envVars := map[string]env.Setter{}
-	envVars["KOLLA_CONFIG_STRATEGY"] = env.SetValue("COPY_ALWAYS")
-	envVars["ENABLE_DESIGNATE"] = env.SetValue("yes")
-	envVars["ENABLE_HEAT"] = env.SetValue("yes")
-	envVars["ENABLE_IRONIC"] = env.SetValue("yes")
-	envVars["ENABLE_MANILA"] = env.SetValue("yes")
-	envVars["ENABLE_OCTAVIA"] = env.SetValue("yes")
-	envVars["ENABLE_WATCHER"] = env.SetValue(enabledServices["watcher"])
-	envVars["CONFIG_HASH"] = env.SetValue(configHash)
+	livenessProbe := formatProbes()
+	readinessProbe := formatProbes()
+	startupProbe := formatProbes()
+
+	envVars := getEnvVars(configHash, enabledServices)
 
 	// create Volumes and VolumeMounts
 	volumes := getVolumes(instance.Name, instance.Spec.ExtraMounts, HorizonPropagation)
@@ -74,21 +80,25 @@ func Deployment(
 		volumeMounts = append(volumeMounts, instance.Spec.TLS.CreateVolumeMounts(nil)...)
 	}
 
-	readinessProbe := formatReadinessProbe()
-	livenessProbe := formatLivenessProbe()
-	startupProbe := formatStartupProbe()
-
 	if instance.Spec.TLS.Enabled() {
-		svc, err := instance.Spec.TLS.GenericService.ToService()
+		tlsRequiredOptions := TLSRequiredOptions{
+			&containerPort,
+			livenessProbe,
+			readinessProbe,
+			startupProbe,
+			volumes,
+			volumeMounts,
+		}
+
+		err := tlsRequiredOptions.formatTLSOptions(instance)
 		if err != nil {
 			return nil, err
 		}
-		containerPort.ContainerPort = HorizonPortTLS
-		livenessProbe.HTTPGet.Scheme = corev1.URISchemeHTTPS
-		readinessProbe.HTTPGet.Scheme = corev1.URISchemeHTTPS
-		startupProbe.HTTPGet.Scheme = corev1.URISchemeHTTPS
-		volumes = append(volumes, svc.CreateVolume(ServiceName))
-		volumeMounts = append(volumeMounts, svc.CreateVolumeMounts(ServiceName)...)
+		volumes, volumeMounts = tlsRequiredOptions.volumes, tlsRequiredOptions.volumeMounts
+		livenessProbe = tlsRequiredOptions.livenessProbe
+		readinessProbe = tlsRequiredOptions.readinessProbe
+		startupProbe = tlsRequiredOptions.startupProbe
+		containerPort = *tlsRequiredOptions.containerPort
 	}
 
 	deployment := &appsv1.Deployment{
@@ -155,7 +165,23 @@ func Deployment(
 	return deployment, nil
 }
 
-func formatLivenessProbe() *corev1.Probe {
+func getEnvVars(configHash string, enabledServices map[string]string) map[string]env.Setter {
+
+	envVars := map[string]env.Setter{}
+
+	envVars["KOLLA_CONFIG_STRATEGY"] = env.SetValue("COPY_ALWAYS")
+	envVars["ENABLE_DESIGNATE"] = env.SetValue("yes")
+	envVars["ENABLE_HEAT"] = env.SetValue("yes")
+	envVars["ENABLE_IRONIC"] = env.SetValue("yes")
+	envVars["ENABLE_MANILA"] = env.SetValue("yes")
+	envVars["ENABLE_OCTAVIA"] = env.SetValue("yes")
+	envVars["ENABLE_WATCHER"] = env.SetValue(enabledServices["watcher"])
+	envVars["CONFIG_HASH"] = env.SetValue(configHash)
+
+	return envVars
+}
+
+func formatProbes() *corev1.Probe {
 
 	return &corev1.Probe{
 		TimeoutSeconds:      5,
@@ -170,33 +196,22 @@ func formatLivenessProbe() *corev1.Probe {
 	}
 }
 
-func formatReadinessProbe() *corev1.Probe {
+func (t *TLSRequiredOptions) formatTLSOptions(instance *horizonv1.Horizon) error {
 
-	return &corev1.Probe{
-		TimeoutSeconds:      5,
-		PeriodSeconds:       10,
-		InitialDelaySeconds: 10,
-		ProbeHandler: corev1.ProbeHandler{
-			HTTPGet: &corev1.HTTPGetAction{
-				Path: horizonDashboardURL,
-				Port: intstr.FromString(horizonContainerPortName),
-			},
-		},
+	var err error
+	var svc *tls.Service
+
+	svc, err = instance.Spec.TLS.GenericService.ToService()
+	if err != nil {
+		return err
 	}
-}
 
-func formatStartupProbe() *corev1.Probe {
+	t.containerPort.ContainerPort = HorizonPortTLS
+	t.livenessProbe.HTTPGet.Scheme = corev1.URISchemeHTTPS
+	t.readinessProbe.HTTPGet.Scheme = corev1.URISchemeHTTPS
+	t.startupProbe.HTTPGet.Scheme = corev1.URISchemeHTTPS
+	t.volumes = append(t.volumes, svc.CreateVolume(ServiceName))
+	t.volumeMounts = append(t.volumeMounts, svc.CreateVolumeMounts(ServiceName)...)
 
-	return &corev1.Probe{
-		TimeoutSeconds:      5,
-		PeriodSeconds:       10,
-		FailureThreshold:    30,
-		InitialDelaySeconds: 10,
-		ProbeHandler: corev1.ProbeHandler{
-			HTTPGet: &corev1.HTTPGetAction{
-				Path: horizonDashboardURL,
-				Port: intstr.FromString(horizonContainerPortName),
-			},
-		},
-	}
+	return nil
 }

--- a/pkg/horizon/deployment_test.go
+++ b/pkg/horizon/deployment_test.go
@@ -1,0 +1,142 @@
+package horizon
+
+import (
+	"testing"
+
+	horizonv1 "github.com/openstack-k8s-operators/horizon-operator/api/v1beta1"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/tls"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type testCase struct {
+	name            string
+	instance        *horizonv1.Horizon
+	expectedVolumes []corev1.Volume
+	expectedMounts  []corev1.VolumeMount
+	expectedError   bool
+	errorContains   string
+}
+
+func TestFormatTLSOptions(t *testing.T) {
+
+	var tlsSecretName = "generic-tls-secret"
+	var defaultMode int32 = 256
+	testCases := []testCase{
+		{
+			name: "Valid TLS Configuration",
+			instance: &horizonv1.Horizon{
+				Spec: horizonv1.HorizonSpec{
+					HorizonSpecCore: horizonv1.HorizonSpecCore{
+						TLS: tls.SimpleService{
+							GenericService: tls.GenericService{
+								SecretName: &tlsSecretName,
+							},
+						},
+					},
+				},
+			},
+			expectedVolumes: []corev1.Volume{
+				{
+					Name: "horizon-tls-certs",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName:  "generic-tls-secret",
+							DefaultMode: &defaultMode,
+						},
+					},
+				},
+				{Name: "combined-ca-bundle",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName:  "combined-ca-bundle",
+							DefaultMode: &defaultMode,
+						},
+					},
+				},
+				{
+					Name: "config-data",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							DefaultMode: &defaultMode,
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "horizon-config-data",
+							},
+						},
+					},
+				},
+				{
+					Name: "horizon-secret-key",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName:  ServiceName,
+							DefaultMode: &defaultMode,
+						},
+					},
+				},
+			},
+
+			expectedMounts: []corev1.VolumeMount{
+				{
+					Name:             "horizon-tls-certs",
+					MountPath:        "/var/lib/config-data/tls/certs/horizon.crt",
+					ReadOnly:         true,
+					SubPath:          "tls.crt",
+					MountPropagation: nil,
+					SubPathExpr:      "",
+				},
+				{
+					Name:             "combined-ca-bundle",
+					ReadOnly:         true,
+					SubPath:          "tls-ca-bundle.pem",
+					MountPath:        "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",
+					MountPropagation: nil,
+					SubPathExpr:      "",
+				},
+				{
+					Name:             "horizon-tls-certs",
+					ReadOnly:         true,
+					SubPath:          "tls.key",
+					MountPath:        "/var/lib/config-data/tls/private/horizon.key",
+					MountPropagation: nil,
+					SubPathExpr:      "",
+				},
+			},
+			expectedError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			options := &TLSRequiredOptions{
+				containerPort:  &corev1.ContainerPort{},
+				livenessProbe:  &corev1.Probe{ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{}}},
+				readinessProbe: &corev1.Probe{ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{}}},
+				startupProbe:   &corev1.Probe{ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{}}},
+			}
+
+			err := options.formatTLSOptions(tc.instance)
+
+			if tc.expectedError {
+				assert.Error(t, err)
+				if tc.errorContains != "" {
+					assert.Contains(t, err.Error(), tc.errorContains)
+				}
+			} else {
+				assert.NoError(t, err)
+				for _, elem := range options.volumes {
+					assert.Contains(t, tc.expectedVolumes, elem)
+				}
+				for _, elem := range options.volumeMounts {
+					assert.Contains(t, tc.expectedMounts, elem)
+				}
+
+				assert.Equal(t, corev1.URISchemeHTTPS, options.livenessProbe.HTTPGet.Scheme)
+				assert.Equal(t, corev1.URISchemeHTTPS, options.readinessProbe.HTTPGet.Scheme)
+				assert.Equal(t, corev1.URISchemeHTTPS, options.startupProbe.HTTPGet.Scheme)
+				assert.Equal(t, int32(HorizonPortTLS), options.containerPort.ContainerPort)
+
+			}
+		})
+	}
+}

--- a/tests/functional/horizon_controller_test.go
+++ b/tests/functional/horizon_controller_test.go
@@ -279,6 +279,12 @@ var _ = Describe("Horizon controller", func() {
 			Expect(deployment.Spec.Template.Spec.Containers[0].Env).
 				To(ContainElement(corev1.EnvVar{Name: "ENABLE_OCTAVIA", Value: "yes", ValueFrom: nil}))
 		})
+		It("Should have liveness, readiness and startup Probes defined", func() {
+			deployment := th.GetDeployment(deploymentName)
+			Expect(deployment.Spec.Template.Spec.Containers[0].LivenessProbe.ProbeHandler.HTTPGet.Path).To(Equal("/dashboard/auth/login/?next=/dashboard/"))
+			Expect(deployment.Spec.Template.Spec.Containers[0].StartupProbe.ProbeHandler.HTTPGet.Path).To(Equal("/dashboard/auth/login/?next=/dashboard/"))
+			Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.ProbeHandler.HTTPGet.Path).To(Equal("/dashboard/auth/login/?next=/dashboard/"))
+		})
 	})
 
 	When("watcher keystone service exists", func() {


### PR DESCRIPTION
This change does some refactoring of the deployment.go code to avoid overuse of string literals and replace with consts. Along with moving excessive code from the main Deployment function into dedicated functions that are easier to test and read.

The second commit adds a dedicated `deployment_test.go` file. This will allow us to perform more comprehensive testing of the individual functions without depending on the limited number of scenarios we're running with envtest.