### PR TITLE
Remove OLM webhooks when running 'make run-with-webhook'

### DIFF
--- a/hack/configure_local_webhook.sh
+++ b/hack/configure_local_webhook.sh
@@ -87,3 +87,5 @@ webhooks:
 EOF_CAT
 
 oc apply -n openstack -f ${TMPDIR}/patch_webhook_configurations.yaml
+
+oc patch "$(oc get csv -n openstack-operators -l operators.coreos.com/horizon-operator.openstack-operators -o name)" -n openstack-operators --type=json -p="[{'op': 'remove', 'path': '/spec/webhookdefinitions'}]" || true


### PR DESCRIPTION
When using `make run-with-webhook`, local versions of the operator and its webhooks are added to the cluster.  If the operator was previously installed via OLM, then there might be lingering webhooks from that installation.  We've previously been assuming that the user would manually remove them, but we should just get rid of them ourselves since those OLM webhooks need to be deleted anyhow for the local webhooks to function unimpeded.