### PR TITLE
Add kuttl tests for extramounts option

### DIFF
--- a/tests/kuttl/tests/basic-deployment/02-assert-update-extramounts-horizon.yaml
+++ b/tests/kuttl/tests/basic-deployment/02-assert-update-extramounts-horizon.yaml
@@ -1,0 +1,22 @@
+apiVersion: horizon.openstack.org/v1beta1
+kind: Horizon
+metadata:
+  name: horizon
+spec:
+  extraMounts:
+    - extraVol:
+      - extraVolType: Policy
+        mounts:
+        - mountPath: /etc/openstack-dashboard/mycustomPolicy.yaml
+          name: policy
+          readOnly: true
+          subPath: mycustomPolicy.yaml
+        volumes:
+        - name: policy
+      name: v1
+      region: r1
+  replicas: 1
+  secret: "osp-secret"
+  customServiceConfig: |
+    DEBUG = True
+    LOGGING['handlers']['console']['level'] = 'DEBUG'

--- a/tests/kuttl/tests/basic-deployment/02-update-extramounts-horizon.yaml
+++ b/tests/kuttl/tests/basic-deployment/02-update-extramounts-horizon.yaml
@@ -1,0 +1,39 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      touch mycustompolicy.yaml
+      oc create configmap -n $NAMESPACE horizon-policy --from-file mycustompolicy.yaml
+
+  - script: |
+      oc patch horizon -n $NAMESPACE horizon --type='merge' -p '{
+        "spec": {
+          "extraMounts": [
+            {
+              "name": "v1",
+              "region": "r1",
+              "extraVol": [
+                {
+                  "extraVolType": "Policy",
+                  "mounts": [
+                    {
+                      "mountPath": "/etc/openstack-dashboard/mycustomPolicy.yaml",
+                      "name": "policy",
+                      "readOnly": true,
+                      "subPath": "mycustomPolicy.yaml"
+                    }
+                  ],
+                  "volumes": [
+                    {
+                      "name": "policy",
+                      "configMap": {
+                        "name": "horizon-policy"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      }'


### PR DESCRIPTION
This commit updates the horizon deployment spec to incorporate extramounts mounting the file to a particular path and assert the resulting Deployment to verify that it contains the mountpoint destined to the file