### PR TITLE
Ensure nodeSelector logic is consistent for all operators

### DIFF
--- a/api/v1beta1/horizon_types.go
+++ b/api/v1beta1/horizon_types.go
@@ -47,7 +47,7 @@ type HorizonSpec struct {
 type HorizonSpecCore struct {
 	// +kubebuilder:validation:Optional
 	// NodeSelector to target subset of worker nodes running this service
-	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+	NodeSelector *map[string]string `json:"nodeSelector,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// ConfigOverwrite - interface to overwrite default config files like e.g. logging.conf or policy.json.

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -165,9 +165,13 @@ func (in *HorizonSpecCore) DeepCopyInto(out *HorizonSpecCore) {
 	*out = *in
 	if in.NodeSelector != nil {
 		in, out := &in.NodeSelector, &out.NodeSelector
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
+		*out = new(map[string]string)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make(map[string]string, len(*in))
+			for key, val := range *in {
+				(*out)[key] = val
+			}
 		}
 	}
 	if in.DefaultConfigOverwrite != nil {

--- a/pkg/horizon/deployment.go
+++ b/pkg/horizon/deployment.go
@@ -165,7 +165,7 @@ func Deployment(
 		},
 		corev1.LabelHostname,
 	)
-	if instance.Spec.NodeSelector != nil && len(*instance.Spec.NodeSelector) > 0 {
+	if instance.Spec.NodeSelector != nil {
 		deployment.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
 	}
 

--- a/pkg/horizon/deployment.go
+++ b/pkg/horizon/deployment.go
@@ -165,8 +165,8 @@ func Deployment(
 		},
 		corev1.LabelHostname,
 	)
-	if instance.Spec.NodeSelector != nil && len(instance.Spec.NodeSelector) > 0 {
-		deployment.Spec.Template.Spec.NodeSelector = instance.Spec.NodeSelector
+	if instance.Spec.NodeSelector != nil && len(*instance.Spec.NodeSelector) > 0 {
+		deployment.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
 	}
 
 	return deployment, nil


### PR DESCRIPTION
nodeSelectors are not currently applied consistently across all operators.

Some do not support nodeSelectors at all - will be implemented in this series of pull requests.
Some do not apply them to every pod (jobs/cronjobs esp) - will be resolved in this series of pull requests.
Some do not apply a node selector update correctly, only when not initially set.
Some support nodeSelectors but do not inherit the default nodeSelector from the OpenstackControlPlane CR.

Jira: [OSPRH-10734](https://issues.redhat.com//browse/OSPRH-10734)