### PR TITLE
kuttl: switch reports to JUnitXML instead of JSON

### DIFF
--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestSuite
-reportFormat: JSON
+reportFormat: xml
 reportName: kuttl-test-horizon
 namespace: horizon-kuttl-tests
 timeout: 180


### PR DESCRIPTION
JUnitXML is the de-facto standard format for test reporting and widely supported by all tools which post-process test results.