### PR TITLE
[httpd] Use absolute url with schema in redirect rule

### DIFF
--- a/controllers/horizon_controller.go
+++ b/controllers/horizon_controller.go
@@ -888,14 +888,15 @@ func (r *HorizonReconciler) generateServiceConfigMaps(
 	}
 
 	templateParameters := map[string]interface{}{
-		"keystoneURL":        authURL,
-		"horizonEndpointUrl": url.Host,
-		"memcachedServers":   mc.GetMemcachedServerListQuotedString(),
-		"memcachedTLS":       mc.GetMemcachedTLSSupport(),
-		"ServerName":         fmt.Sprintf("%s.%s.svc", horizon.ServiceName, instance.Namespace),
-		"Port":               horizon.HorizonPort,
-		"TLS":                false,
-		"isPublicHTTPS":      url.Scheme == "https",
+		"keystoneURL":         authURL,
+		"horizonEndpoint":     instance.Status.Endpoint,
+		"horizonEndpointHost": url.Host,
+		"memcachedServers":    mc.GetMemcachedServerListQuotedString(),
+		"memcachedTLS":        mc.GetMemcachedTLSSupport(),
+		"ServerName":          fmt.Sprintf("%s.%s.svc", horizon.ServiceName, instance.Namespace),
+		"Port":                horizon.HorizonPort,
+		"TLS":                 false,
+		"isPublicHTTPS":       url.Scheme == "https",
 	}
 
 	// create httpd tls template parameters

--- a/templates/horizon/config/httpd.conf
+++ b/templates/horizon/config/httpd.conf
@@ -57,7 +57,7 @@ LogLevel debug
   CustomLog /dev/stdout "%a %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" env=forwarded
 
   ## RedirectMatch rules
-  RedirectMatch permanent  ^/$ /dashboard
+  RedirectMatch permanent  ^/$ "{{ .horizonEndpoint }}/dashboard"
 
   ## WSGI configuration
   WSGIApplicationGroup %{GLOBAL}

--- a/templates/horizon/config/local_settings.py
+++ b/templates/horizon/config/local_settings.py
@@ -64,18 +64,26 @@ DEBUG = False
 def get_pod_ip():
     import socket
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    hostport = (
+        "{{ .horizonEndpointHost }}",
+        {{- if .isPublicHTTPS }}
+        443
+        {{- else }}
+        80
+        {{- end }}
+    )
     try:
-        s.connect(("{{ .horizonEndpointUrl }}", 80))
+        s.connect(hostport)
         return s.getsockname()[0]
     except socket.gaierror:
         s.close()
         s = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
-        s.connect(("{{ .horizonEndpointUrl }}", 80))
+        s.connect(hostport)
         return "[{}]".format(s.getsockname()[0])
     finally:
         s.close()
 
-ALLOWED_HOSTS = [get_pod_ip(), "{{ .horizonEndpointUrl }}"]
+ALLOWED_HOSTS = [get_pod_ip(), "{{ .horizonEndpointHost }}"]
 
 USE_X_FORWARDED_HOST = True
 


### PR DESCRIPTION
Use the endpoint in the redirect rule to ensure it references the correct base url and schema which can be different to the current schema when TLS is terminated at the route

Added horizonEndpoint template param with the full url, renamed the incorrectly named horizonEndpointUrl to horizonEndpointHost.

Jira: [OSPRH-12005](https://issues.redhat.com//browse/OSPRH-12005)