### PR TITLE
Set ENABLE_WATCHER env variable to yes if watcher service exists

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -127,6 +127,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - keystone.openstack.org
+  resources:
+  - keystoneservices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - memcached.openstack.org
   resources:
   - memcacheds

--- a/pkg/horizon/deployment.go
+++ b/pkg/horizon/deployment.go
@@ -38,6 +38,7 @@ func Deployment(
 	configHash string,
 	labels map[string]string,
 	annotations map[string]string,
+	enabledServices map[string]string,
 ) (*appsv1.Deployment, error) {
 	runAsUser := int64(0)
 
@@ -92,6 +93,7 @@ func Deployment(
 	envVars["ENABLE_IRONIC"] = env.SetValue("yes")
 	envVars["ENABLE_MANILA"] = env.SetValue("yes")
 	envVars["ENABLE_OCTAVIA"] = env.SetValue("yes")
+	envVars["ENABLE_WATCHER"] = env.SetValue(enabledServices["watcher"])
 	envVars["CONFIG_HASH"] = env.SetValue(configHash)
 
 	// create Volumes and VolumeMounts


### PR DESCRIPTION
A new watcher-operator is being created [1].

It is desired that the watcher-dashboard is enabled in the horizon container if the service is deployed.

This patch is setting the env variable ENABLE_WATCHER to `yes` if the keystone service "watcher" is present. Otherwise, it is set to default value `no`.

Related: [OSPRH-11277](https://issues.redhat.com/browse/OSPRH-11277)