### PR TITLE
Permit hostmount-anyuid for Horizon Service Account

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -173,6 +173,14 @@ rules:
   verbs:
   - use
 - apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - hostmount-anyuid
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+- apiGroups:
   - topology.openstack.org
   resources:
   - topologies

--- a/controllers/horizon_controller.go
+++ b/controllers/horizon_controller.go
@@ -109,6 +109,7 @@ type HorizonReconciler struct {
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update;patch
 // service account permissions that are needed to grant permission to the above
 // +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid,resources=securitycontextconstraints,verbs=use
+// +kubebuilder:rbac:groups="security.openshift.io",resourceNames=hostmount-anyuid,resources=securitycontextconstraints,verbs=use
 // +kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=k8s.cni.cncf.io,resources=network-attachment-definitions,verbs=get;list;watch
 // service account, role, rolebinding
@@ -1123,7 +1124,7 @@ func configureHorizonRbac(ctx context.Context, helper *helper.Helper, instance *
 	rbacRules := []rbacv1.PolicyRule{
 		{
 			APIGroups:     []string{"security.openshift.io"},
-			ResourceNames: []string{"anyuid"},
+			ResourceNames: []string{"anyuid", "hostmount-anyuid"},
 			Resources:     []string{"securitycontextconstraints"},
 			Verbs:         []string{"use"},
 		},


### PR DESCRIPTION
This change adds the hostmount-anyuid permission to the horizon Service Account. This will ensure that users are able to leverage NFS shares via the ExtraMounts interface. Without this permission, we would need to set privileged: true on the deployment, which ideally we would like to avoid.

This can be removed once we are no longer running with UID 0.