### PR TITLE
Exit early if no openstack secret is provided

### DIFF
--- a/controllers/horizon_controller.go
+++ b/controllers/horizon_controller.go
@@ -611,11 +611,15 @@ func (r *HorizonReconciler) reconcileNormal(ctx context.Context, instance *horiz
 	// We can't reconcile without a valid OpenStack secret. Exit early here and update the status.conditions to
 	// inform users of the issue.
 	if instance.Spec.Secret == "" {
+
+		var missingDependenciesReason condition.Reason = "missing dependencies"
+		var missingDependenciesMessage = "missing openstack secret"
+
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.InputReadyCondition,
-			condition.RequestedReason,
+			missingDependenciesReason,
 			condition.SeverityInfo,
-			condition.InputReadyWaitingMessage))
+			missingDependenciesMessage))
 
 		return ctrl.Result{}, fmt.Errorf("no openstack secret has been provided. Unable to reconcile")
 	}

--- a/tests/functional/horizon_controller_test.go
+++ b/tests/functional/horizon_controller_test.go
@@ -142,6 +142,30 @@ var _ = Describe("Horizon controller", func() {
 		})
 	})
 
+	When("No secret is provided", func() {
+		BeforeEach(func() {
+			horizonSpec := GetDefaultHorizonSpec()
+			horizonSpec["secret"] = ""
+
+			DeferCleanup(th.DeleteInstance, CreateHorizon(horizonName, horizonSpec))
+		})
+
+		It("Should set the inputReady condition to false", func() {
+
+			var missingDependenciesReason condition.Reason = "missing dependencies"
+			var missingDependenciesMessage = "missing openstack secret"
+
+			th.ExpectConditionWithDetails(
+				horizonName,
+				ConditionGetterFunc(HorizonConditionGetter),
+				condition.InputReadyCondition,
+				corev1.ConditionFalse,
+				missingDependenciesReason,
+				missingDependenciesMessage,
+			)
+		})
+	})
+
 	When("Memcached instance is available", func() {
 		BeforeEach(func() {
 			DeferCleanup(th.DeleteInstance, CreateHorizon(horizonName, GetDefaultHorizonSpec()))


### PR DESCRIPTION
We depend on a valid openstack secret in order to reconcile Horizon, this change ensures that we exit the reconcile early if no secret is provided.

https://issues.redhat.com/browse/OSPRH-10075