### PR TITLE
Do not run horizon with root user

### DIFF
--- a/api/v1beta1/horizon_types.go
+++ b/api/v1beta1/horizon_types.go
@@ -52,7 +52,7 @@ type HorizonSpec struct {
 	HorizonSpecCore `json:",inline"`
 }
 
-// HorizonSpecBase -
+// HorizonSpecCore -
 type HorizonSpecCore struct {
 	// +kubebuilder:validation:Optional
 	// NodeSelector to target subset of worker nodes running this service

--- a/controllers/horizon_controller.go
+++ b/controllers/horizon_controller.go
@@ -51,6 +51,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/ptr"
@@ -79,7 +80,7 @@ func (r *HorizonReconciler) GetScheme() *runtime.Scheme {
 	return r.Scheme
 }
 
-// GetLog returns a logger object with a prefix of "controller.name" and additional controller context fields
+// GetLogger - returns a logger object with a prefix of "controller.name" and additional controller context fields
 func (r *HorizonReconciler) GetLogger(ctx context.Context) logr.Logger {
 	return log.FromContext(ctx).WithName("Controllers").WithName("Horizon")
 }
@@ -475,12 +476,14 @@ func (r *HorizonReconciler) reconcileInit(
 	}
 
 	servicePort := corev1.ServicePort{
-		Name:     endpointName,
-		Port:     horizon.HorizonPort,
-		Protocol: corev1.ProtocolTCP,
+		Name:       endpointName,
+		Port:       horizon.HorizonSvcPort,
+		TargetPort: intstr.FromInt32(horizon.HorizonPort),
+		Protocol:   corev1.ProtocolTCP,
 	}
 	if instance.Spec.TLS.Enabled() {
-		servicePort.Port = horizon.HorizonPortTLS
+		servicePort.Port = horizon.HorizonSvcPortTLS
+		servicePort.TargetPort = intstr.FromInt32(horizon.HorizonPortTLS)
 	}
 
 	// Create the service

--- a/pkg/horizon/const.go
+++ b/pkg/horizon/const.go
@@ -26,11 +26,17 @@ const (
 	// DatabaseName -
 	DatabaseName = "horizon"
 
-	// HorizonPort -
-	HorizonPort int32 = 80
+	// HorizonSvcPort - It maps the Svc (80) to the Container Port (8080)
+	HorizonSvcPort int32 = 80
+
+	// HorizonPort - used by httpd inside the Horizon container
+	HorizonPort int32 = 8080
+
+	// HorizonSvcPortTLS - It maps the Svc (443) to the Container Port (8443)
+	HorizonSvcPortTLS int32 = 443
 
 	// HorizonPortTLS -
-	HorizonPortTLS int32 = 443
+	HorizonPortTLS int32 = 8443
 
 	// HorizonPortName -
 	HorizonPortName = "horizon"
@@ -38,9 +44,17 @@ const (
 	// HorizonExtraVolTypeUndefined can be used to label an extraMount which is
 	// not associated to anything in particular
 	HorizonExtraVolTypeUndefined storage.ExtraVolType = "Undefined"
+
 	// Horizon is the global ServiceType that refers to all the components deployed
 	// by the horizon-operator
 	Horizon storage.PropagationType = "Horizon"
+
+	// ApacheUID - apache uid inside the horizon container
+	ApacheUID int64 = 48
+
+	// KollaUID - assigned as additional group, is required by the bootstrap process
+	// https://github.com/openstack/kolla/blob/master/kolla/common/users.py
+	KollaUID int64 = 42400
 )
 
 // HorizonPropagation is the  definition of the Horizon propagation service

--- a/pkg/horizon/deployment.go
+++ b/pkg/horizon/deployment.go
@@ -36,6 +36,7 @@ const (
 	horizonContainerPortName = "horizon"
 )
 
+// TLSRequiredOptions -
 type TLSRequiredOptions struct {
 	containerPort  *corev1.ContainerPort
 	livenessProbe  *corev1.Probe
@@ -54,7 +55,6 @@ func Deployment(
 	enabledServices map[string]string,
 	topology *topologyv1.Topology,
 ) (*appsv1.Deployment, error) {
-	runAsUser := int64(0)
 
 	args := []string{"-c", ServiceCommand}
 
@@ -117,18 +117,16 @@ func Deployment(
 							Name: ServiceName,
 							Command: []string{
 								"/bin/bash"},
-							Args:  args,
-							Image: instance.Spec.ContainerImage,
-							SecurityContext: &corev1.SecurityContext{
-								RunAsUser: &runAsUser,
-							},
-							Env:            env.MergeEnvs([]corev1.EnvVar{}, envVars),
-							VolumeMounts:   volumeMounts,
-							Resources:      instance.Spec.Resources,
-							ReadinessProbe: readinessProbe,
-							LivenessProbe:  livenessProbe,
-							StartupProbe:   startupProbe,
-							Ports:          []corev1.ContainerPort{containerPort},
+							Args:            args,
+							Image:           instance.Spec.ContainerImage,
+							SecurityContext: HttpdSecurityContext(),
+							Env:             env.MergeEnvs([]corev1.EnvVar{}, envVars),
+							VolumeMounts:    volumeMounts,
+							Resources:       instance.Spec.Resources,
+							ReadinessProbe:  readinessProbe,
+							LivenessProbe:   livenessProbe,
+							StartupProbe:    startupProbe,
+							Ports:           []corev1.ContainerPort{containerPort},
 						},
 					},
 					Volumes: volumes,

--- a/pkg/horizon/funcs.go
+++ b/pkg/horizon/funcs.go
@@ -1,0 +1,20 @@
+package horizon
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+)
+
+// HttpdSecurityContext -
+func HttpdSecurityContext() *corev1.SecurityContext {
+	return &corev1.SecurityContext{
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{
+				"MKNOD",
+			},
+		},
+		RunAsUser:                ptr.To(ApacheUID),
+		RunAsGroup:               ptr.To(KollaUID),
+		AllowPrivilegeEscalation: ptr.To(true),
+	}
+}

--- a/templates/horizon/config/horizon.json
+++ b/templates/horizon/config/horizon.json
@@ -4,54 +4,69 @@
         {
             "source": "/var/lib/config-data/default/httpd.conf",
             "dest": "/etc/httpd/conf/httpd.conf",
-            "merge": false,
-            "preserve_properties": true,
+            "owner": "apache:apache",
             "perm": "0644"
         },
         {
             "source": "/var/lib/config-data/default/ssl.conf",
             "dest": "/etc/httpd/conf.d/ssl.conf",
-            "merge": false,
-            "preserve_properties": true,
+            "optional": true,
+            "owner": "apache:apache",
             "perm": "0644"
         },
         {
             "source": "/run/openstack-dashboard/.secrets/horizon-secret",
             "dest": "/etc/openstack-dashboard/.horizon-secret",
-            "merge": false,
-            "preserve_properties": true,
+            "owner": "apache:apache",
             "perm": "0600"
         },
         {
             "source": "/var/lib/config-data/default/local_settings.py",
             "dest": "/etc/openstack-dashboard/local_settings",
-            "merge": false,
-            "preserve_properties": true
+            "owner": "apache:apache",
+            "perm": "0644",
+            "merge": true
         },
         {
             "source": "/var/lib/config-data/default/9999_custom_settings.py",
             "dest": "/etc/openstack-dashboard/local_settings.d/9999_custom_settings.py",
-            "merge": false,
-            "preserve_properties": true
+            "owner": "apache:apache",
+            "perm": "0644",
+            "merge": true
         },
         {
             "source": "/var/lib/config-data/tls/certs/*",
             "dest": "/etc/pki/tls/certs/",
-            "owner": "root",
+            "owner": "apache:apache",
             "perm": "0640",
-            "optional": true,
-            "merge": true
+            "merge": true,
+            "optional": true
         },
         {
             "source": "/var/lib/config-data/tls/private/*",
             "dest": "/etc/pki/tls/private/",
-            "owner": "root",
-            "perm": "0600",
+            "owner": "apache:apache",
+            "perm": "0640",
             "optional": true,
             "merge": true
         }
     ],
     "permissions": [
+        {
+            "path": "/var/lib/kolla",
+            "owner": "apache:apache",
+            "recurse": true
+        },
+        {
+            "path": "/etc/httpd/run",
+            "owner": "apache:apache",
+            "recurse": true
+        },
+        {
+            "path": "/etc/httpd/logs",
+            "owner": "apache:apache",
+            "recurse": true
+        },
         {
             "path": "/var/log/horizon",
             "owner": "apache:apache",

--- a/tests/kuttl/tests/tls-deployment/01-assert.yaml
+++ b/tests/kuttl/tests/tls-deployment/01-assert.yaml
@@ -39,7 +39,7 @@ spec:
             scheme: HTTPS
         name: horizon
         ports:
-        - containerPort: 443
+        - containerPort: 8443
           name: horizon
           protocol: TCP
         readinessProbe:


### PR DESCRIPTION
This patch removes `root` from `horizon` `Pods`. The operator now builds pods using the `kolla` provided `user/group`. As a result of that an additional security context has been defined for the running container.

Jira: https://issues.redhat.com/browse/OSPRH-15373