### PR TITLE
Enable MTLS memcached auth

### DIFF
--- a/templates/horizon/config/horizon.json
+++ b/templates/horizon/config/horizon.json
@@ -49,6 +49,22 @@
             "perm": "0640",
             "optional": true,
             "merge": true
+        },
+        {
+          "source": "/var/lib/config-data/mtls/certs/*",
+          "dest": "/etc/pki/tls/certs/",
+          "owner": "apache:apache",
+          "perm": "0640",
+          "optional": true,
+          "merge": true
+        },
+        {
+          "source": "/var/lib/config-data/mtls/private/*",
+          "dest": "/etc/pki/tls/private/",
+          "owner": "apache:apache",
+          "perm": "0600",
+          "optional": true,
+          "merge": true
         }
     ],
     "permissions": [


### PR DESCRIPTION
This commit allows operators to use mtls as an authentication method against Memcached.
Horizon controller will detect the presence of a purposely-created mtls certificate (authCertSecret) and use this to configure the tls_context accordingly.
Additional volumes/volumemounts will be appended to each pod.