### PR TITLE
Switch endpoints to publicURL

### DIFF
--- a/templates/horizon/config/local_settings.py
+++ b/templates/horizon/config/local_settings.py
@@ -27,7 +27,7 @@ LOGIN_URL = '/dashboard/auth/login/'
 LOGOUT_URL = '/dashboard/auth/logout/'
 LOGIN_REDIRECT_URL = '/dashboard/'
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
-OPENSTACK_ENDPOINT_TYPE = "internalURL"
+OPENSTACK_ENDPOINT_TYPE = "publicURL"
 OPENSTACK_API_VERSIONS = {
   'identity': 3,
 }


### PR DESCRIPTION
This patch switches the default behavior to consume `public endpoints`. It might be patched using `customServiceConfig`, but this ensures that we do not leak sensitive data exposed by `Glance internal deployments` [1].
This reverts the commit where we needed to workaround the tls-e that wasn't ready at that time.

```
    Horizon should use internalURL endpoints
    
    Horizon currently uses the Public endpoints. This causes issues with the
    current implementation of self-signed cert-manager Issuer. We ultimately
    need to resolve this trust issue, but in lieu of an established standard
    for trusting these certs, we will work around this for now by not
    relying on the public endpoints.

diff --git a/templates/horizon/config/local_settings.py b/templates/horizon/config/local_settings.py
index 38d9cca..05f97f5 100644
--- a/templates/horizon/config/local_settings.py
+++ b/templates/horizon/config/local_settings.py
@@ -26,6 +26,7 @@ LOGIN_URL = '/dashboard/auth/login/'
 LOGOUT_URL = '/dashboard/auth/logout/'
 LOGIN_REDIRECT_URL = '/dashboard/'
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+OPENSTACK_ENDPOINT_TYPE = "internalURL"
 OPENSTACK_API_VERSIONS = {
   'identity': 3,
 }
 ```

Jira: https://issues.redhat.com/browse/OSPRH-18448

[1] https://github.com/openstack-k8s-operators/glance-operator/blob/main/docs/design-decisions.md#design-decisions