### PR TITLE
Removed TLS hook for include conf.d/*.conf

### DIFF
--- a/templates/horizon/config/httpd.conf
+++ b/templates/horizon/config/httpd.conf
@@ -13,10 +13,7 @@ Listen {{ .Port }}
 TypesConfig /etc/mime.types
 
 Include conf.modules.d/*.conf
-{{- if .TLS }}
-## TODO: fix default ssl.conf to comment not available tls certs. Than we can remove this condition
 Include conf.d/*.conf
-{{- end }}
 
 LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
 LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" proxy


### PR DESCRIPTION
Removed TLS hook for include conf.d/*.conf
- this is to help support the change/setting of LimitRequestBody in httpd.conf

Jira: https://issues.redhat.com/browse/OSPRH-18585 