### PR TITLE
Set HORIZON_IMAGES_UPLOAD_MODE to direct

### DIFF
--- a/templates/horizon/config/local_settings.py
+++ b/templates/horizon/config/local_settings.py
@@ -37,6 +37,7 @@ HORIZON_CONFIG["password_validator"] = {
 }
 HORIZON_CONFIG["enforce_password_check"] = True
 POLICY_FILES_PATH = '/etc/openstack-dashboard'
+HORIZON_IMAGES_UPLOAD_MODE = 'direct'
 
 DEBUG = False
 # This setting controls whether or not compression is enabled. Disabling


### PR DESCRIPTION
When not specified, `HORIZON_IMAGES_UPLOAD_MODE` has `legacy` as default value [0].
Because we already patched `glance-operator` to set the `cors` section automatically when horizon is enabled [1], this change allows horizon to rely on `direct` mode.

[0] https://docs.openstack.org/horizon/latest/configuration/settings.html#horizon-images-upload-mode
[1] https://github.com/openstack-k8s-operators/glance-operator/pull/787