### PR TITLE
[OSPRH-20276] Improve consistency of condition severity usage

### DIFF
--- a/tests/functional/horizon_controller_test.go
+++ b/tests/functional/horizon_controller_test.go
@@ -739,7 +739,7 @@ var _ = Describe("Horizon controller", func() {
 				ConditionGetterFunc(HorizonConditionGetter),
 				condition.TLSInputReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				fmt.Sprintf("TLSInput is missing: %s", CABundleSecretName),
 			)
 			th.ExpectCondition(


### PR DESCRIPTION
Use consistent condition severity across repeated patterns found in our operators, and otherwise use an appropriate severity for conditions unique to each operator.

Jira: https://issues.redhat.com/browse/OSPRH-20276

Co-authored-by: Claude (Anthropic) [claude@anthropic.com](mailto:claude@anthropic.com)