### PR TITLE
Use lib-common DownwardAPI to retrieve pod IP

### DIFF
--- a/internal/horizon/deployment.go
+++ b/internal/horizon/deployment.go
@@ -191,6 +191,7 @@ func getEnvVars(configHash string, enabledServices map[string]string) map[string
 	envVars["ENABLE_WATCHER"] = env.SetValue(enabledServices["watcher"])
 	envVars["CONFIG_HASH"] = env.SetValue(configHash)
 	envVars["UNPACK_THEME"] = env.SetValue("true")
+	envVars["POD_IP"] = env.DownwardAPI("status.podIP")
 
 	return envVars
 }


### PR DESCRIPTION
This change uses the `lib-common` env `DownwardAPI` [1] to write the pods IP to the env vars of the pod. We then retrieve this in `local_settings.py` to populate `ALLOWED_HOSTS`.

[1] https://github.com/openstack-k8s-operators/lib-common/blob/main/modules/common/env/env.go#L100-L114

Fixes #487
 Jira: https://issues.redhat.com/browse/OSPRH-19216