### PR TITLE
OSPRH-28889: Horizon: PQC compliance -- enforce TLS 1.3 and block kRSA

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -124,6 +124,12 @@ func main() {
 		tlsOpts = append(tlsOpts, disableHTTP2)
 	}
 
+	// PQC: Enforce TLS 1.3 minimum for quantum-safe key exchange (X25519MLKEM768).
+	// Go 1.24+ enables hybrid ML-KEM by default, but only when TLS 1.3 is negotiated.
+	tlsOpts = append(tlsOpts, func(c *tls.Config) {
+		c.MinVersion = tls.VersionTLS13
+	})
+
 	// Create watchers for metrics and webhooks certificates
 	var metricsCertWatcher, webhookCertWatcher *certwatcher.CertWatcher
 

--- a/templates/horizon/config/ssl.conf
+++ b/templates/horizon/config/ssl.conf
@@ -15,7 +15,7 @@
   SSLHonorCipherOrder On
   SSLUseStapling Off
   SSLStaplingCache "shmcb:/run/httpd/ssl_stapling(32768)"
-  SSLCipherSuite HIGH:MEDIUM:!aNULL:!MD5:!RC4:!3DES
-  SSLProtocol all -SSLv2 -SSLv3 -TLSv1
+  SSLCipherSuite HIGH:!aNULL:!MD5:!RC4:!3DES:!kRSA
+  SSLProtocol -all +TLSv1.3 +TLSv1.2
   SSLOptions StdEnvVars
 </IfModule>


### PR DESCRIPTION
Enforce TLS 1.3 as the minimum version in the operator manager
(cmd/main.go) to enable Go 1.24+ hybrid ML-KEM (X25519MLKEM768) key
exchange for quantum-safe TLS connections. Without this, Go defaults to
TLS 1.2 minimum, which only supports classical key exchange vulnerable
to harvest-now-decrypt-later attacks.

Harden the Apache ssl.conf template: drop kRSA cipher suites to
eliminate RSA key exchange (no forward secrecy, quantum-vulnerable) and
replace the ambiguous "all -SSLv2 -SSLv3 -TLSv1" protocol directive
with explicit "-all +TLSv1.3 +TLSv1.2" to guarantee TLS 1.3
availability and remove the TLS 1.1 leak.

Covers [OSPRH-28889](https://redhat.atlassian.net/browse/OSPRH-28889), OSPRH-28891, [OSPRH-28892](https://redhat.atlassian.net/browse/OSPRH-28892)

Assisted-By: Claude Code (Claude Opus 4.6) <noreply@anthropic.com>