### PR TITLE
OSPRH-28889: PQC: Enforce TLS 1.3 minimum for quantum-safe key exchange

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -124,6 +124,12 @@ func main() {
 		tlsOpts = append(tlsOpts, disableHTTP2)
 	}
 
+	// PQC: Enforce TLS 1.3 minimum for quantum-safe key exchange (X25519MLKEM768).
+	// Go 1.24+ enables hybrid ML-KEM by default, but only when TLS 1.3 is negotiated.
+	tlsOpts = append(tlsOpts, func(c *tls.Config) {
+		c.MinVersion = tls.VersionTLS13
+	})
+
 	// Create watchers for metrics and webhooks certificates
 	var metricsCertWatcher, webhookCertWatcher *certwatcher.CertWatcher
 


### PR DESCRIPTION
## Summary

- Enforce `tls.VersionTLS13` as the minimum TLS version for the operator's webhook and metrics servers
- Enables Go 1.24+ to negotiate hybrid X25519MLKEM768 (ML-KEM) post-quantum key exchange by default
- Prevents fallback to TLS 1.2 which cannot negotiate PQC key exchange, mitigating Harvest Now, Decrypt Later (HNDL) exposure

## Context

NIST has standardized ML-KEM (FIPS 203) for post-quantum key encapsulation. Go 1.24+ automatically negotiates the hybrid X25519MLKEM768 key exchange when both endpoints support TLS 1.3. Without setting `MinVersion: tls.VersionTLS13`, the operator may accept TLS 1.2 connections that cannot use quantum-safe key exchange.

This is PR #1 of the PQC compliance work for horizon-operator ([OSPRH-27427](https://redhat.atlassian.net/browse/OSPRH-27427)).

## Changes

**`cmd/main.go`**: Added a TLS option function that sets `MinVersion` to `tls.VersionTLS13` on the shared `tlsOpts` slice, which feeds both the webhook server and metrics server TLS configurations.

## Validation

- `go build ./...` -- passes
- `go test ./internal/horizon/...` -- passes
- Functional tests require envtest binaries (etcd/kube-apiserver) which are CI-only

## Related tickets

- [OSPRH-28889](https://redhat.atlassian.net/browse/OSPRH-28889): TLS 1.3 MinVersion in cmd/main.go
- [OSPRH-27427](https://redhat.atlassian.net/browse/OSPRH-27427): Parent epic -- PQC compliance for horizon-operator

## Post-merge verification

```bash
# Verify TLS 1.3 on operator webhook:
openssl s_client -connect <webhook-service>:9443 -tls1_3 2>/dev/null | grep "Protocol"
# Expected: Protocol  : TLSv1.3
```