### PR TITLE
Use crypto/rand for Django SECRET_KEY generation

### DIFF
--- a/internal/controller/horizon_controller.go
+++ b/internal/controller/horizon_controller.go
@@ -55,7 +55,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -1188,18 +1187,24 @@ func (r *HorizonReconciler) ensureHorizonSecret(
 	}
 	if k8s_errors.IsNotFound(err) || !validateHorizonSecret(scrt) {
 		Log.Info("Creating Horizon Secret")
+
+		secretKey, err := util.GeneratePassword(50)
+		if err != nil {
+			return fmt.Errorf("generating Horizon SECRET_KEY: %w", err)
+		}
+
 		// Create k8s secret to store Horizon Secret
 		tmpl := []util.Template{
 			{
 				Name:       horizon.ServiceName,
 				Namespace:  instance.Namespace,
 				Type:       util.TemplateTypeNone,
-				CustomData: map[string]string{"horizon-secret": rand.String(10)},
+				CustomData: map[string]string{"horizon-secret": secretKey},
 				Labels:     Labels,
 			},
 		}
 
-		err := oko_secret.EnsureSecrets(ctx, h, instance, tmpl, envVars)
+		err = oko_secret.EnsureSecrets(ctx, h, instance, tmpl, envVars)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Replace math/rand-based rand.String(10) (~47 bits entropy) with lib-common's util.GeneratePassword(50) which uses crypto/rand, matching Django's own default SECRET_KEY length.

The key is used to HMAC-sign CSRF tokens and session cookies.

Existing deployments are not affected — the secret is only generated when it does not already exist (ensureHorizonSecret checks for an existing secret before creating a new one).

Jira: [OSPRH-31813](https://redhat.atlassian.net/browse/OSPRH-31813)