### PR TITLE
Use dedicated startup probe with higher failure threshold

### DIFF
--- a/internal/horizon/deployment.go
+++ b/internal/horizon/deployment.go
@@ -68,7 +68,7 @@ func Deployment(
 
 	livenessProbe := formatProbes()
 	readinessProbe := formatProbes()
-	startupProbe := formatProbes()
+	startupProbe := formatStartupProbe()
 
 	envVars := getEnvVars(configHash, enabledServices)
 
@@ -201,6 +201,21 @@ func formatProbes() *corev1.Probe {
 		TimeoutSeconds:      5,
 		PeriodSeconds:       10,
 		InitialDelaySeconds: 10,
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path: horizonDashboardURL,
+				Port: intstr.FromString(horizonContainerPortName),
+			},
+		},
+	}
+}
+
+func formatStartupProbe() *corev1.Probe {
+
+	return &corev1.Probe{
+		TimeoutSeconds:   5,
+		PeriodSeconds:    10,
+		FailureThreshold: 12,
 		ProbeHandler: corev1.ProbeHandler{
 			HTTPGet: &corev1.HTTPGetAction{
 				Path: horizonDashboardURL,


### PR DESCRIPTION
The startup probe shared the same configuration as liveness/readiness probes, giving Horizon only ~40s to start. In resource-constrained environments startup exceeds this window causing CrashLoopBackOff.

Introduce `formatStartupProbe()` with FailureThreshold: 12 (allowing ~120s for startup), matching the pattern used by Cinder, Glance, and Manila operators.

Assisted-by: Claude Opus 4.6

Note: This is a repeated issue seen in SKMO CI runs that's deploying horizon in main region.