### PR TITLE
Fix client IP logging in Horizon VirtualHost

### DIFF
--- a/templates/horizon/config/httpd.conf
+++ b/templates/horizon/config/httpd.conf
@@ -51,7 +51,9 @@ LogLevel debug
   ## Logging
   ErrorLog {{ .LogFile }}
   ServerSignature Off
-  CustomLog {{ .LogFile }} "%a %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" env=forwarded
+  SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
+  CustomLog {{ .LogFile }} combined env=!forwarded
+  CustomLog {{ .LogFile }} proxy env=forwarded
 
   ## RedirectMatch rules
   RedirectMatch permanent  ^/$ "{{ .horizonEndpoint }}/dashboard"


### PR DESCRIPTION
The `VirtualHost` `CustomLog` directive was overriding the server-level dual-log setup, causing all requests to be logged with the OpenShift router IP instead of the real client IP from `X-Forwarded-For`.

Add `SetEnvIf` and dual `CustomLog` lines inside the `VirtualHost` block to match the `nova-operator` pattern.

Jira: [OSPRH-32110](https://redhat.atlassian.net/browse/OSPRH-32110)