### PR TITLE
Remove deprecated webhook.Defaulter/Validator interface assertions

### DIFF
--- a/api/v1beta1/horizon_webhook.go
+++ b/api/v1beta1/horizon_webhook.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -47,8 +46,6 @@ func SetupHorizonDefaults(defaults HorizonDefaults) {
 	horizonDefaults = defaults
 	horizonlog.Info("Horizon defaults initialized", "defaults", defaults)
 }
-
-var _ webhook.Defaulter = &Horizon{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *Horizon) Default() {
@@ -70,8 +67,6 @@ func (spec *HorizonSpec) Default() {
 func (spec *HorizonSpecCore) Default() {
 	// nothing here yet
 }
-
-var _ webhook.Validator = &Horizon{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *Horizon) ValidateCreate() (admission.Warnings, error) {


### PR DESCRIPTION
These compile-time assertions reference webhook.Defaulter and webhook.Validator interfaces that are removed in controller-runtime v0.21 (OCP 4.20). The assertions are dead code — webhook registration already uses CustomDefaulter/CustomValidator in internal/webhook/.

Removing them makes the API module forward-compatible with CR v0.21 so that consumers (like openstack-operator) can bump controller-runtime without needing replace directives for this operator.

Jira: [OSPRH-32989](https://redhat.atlassian.net/browse/OSPRH-32989)