### PR TITLE
Restore pods RBAC needed for NetworkAttachments verification

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -21,6 +21,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
   - serviceaccounts
   verbs:
   - create

--- a/internal/controller/horizon_controller.go
+++ b/internal/controller/horizon_controller.go
@@ -119,6 +119,7 @@ type HorizonReconciler struct {
 // service account permissions that are needed to grant permission to the above
 // +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid,resources=securitycontextconstraints,verbs=use
 // +kubebuilder:rbac:groups="security.openshift.io",resourceNames=hostmount-anyuid,resources=securitycontextconstraints,verbs=use
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list
 // +kubebuilder:rbac:groups=k8s.cni.cncf.io,resources=network-attachment-definitions,verbs=get;list;watch
 // service account, role, rolebinding
 // +kubebuilder:rbac:groups=topology.openstack.org,resources=topologies,verbs=get;list;watch;update


### PR DESCRIPTION
Commit 45e0ef8 ("Remove unnecessary pods RBAC permissions") dropped the pods kubebuilder RBAC marker from horizon_controller.go, which calls lib-common's VerifyNetworkStatusFromAnnotation to verify NetworkAttachments. That function lists Pods using the controller-manager's own client, so the manager's ClusterRole (config/rbac/role.yaml) needs get;list on pods or Horizon gets stuck in NetworkAttachmentsReady=False with a "pods is forbidden" error, as seen on manila/cinder/neutron-operator after the same cleanup. Restore the get;list marker and regenerate config/rbac/role.yaml. The unused rbacRules grant on the workload service account remains removed, since that really is unused.