### PR TITLE
[18-stable] Remove unnecessary pods RBAC permissions

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,7 +8,6 @@ rules:
   - ""
   resources:
   - configmaps
-  - pods
   - secrets
   - services
   verbs:
@@ -19,6 +18,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
 - apiGroups:
   - ""
   resources:

--- a/internal/controller/horizon_controller.go
+++ b/internal/controller/horizon_controller.go
@@ -119,7 +119,7 @@ type HorizonReconciler struct {
 // service account permissions that are needed to grant permission to the above
 // +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid,resources=securitycontextconstraints,verbs=use
 // +kubebuilder:rbac:groups="security.openshift.io",resourceNames=hostmount-anyuid,resources=securitycontextconstraints,verbs=use
-// +kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list
 // +kubebuilder:rbac:groups=k8s.cni.cncf.io,resources=network-attachment-definitions,verbs=get;list;watch
 // service account, role, rolebinding
 // +kubebuilder:rbac:groups=topology.openstack.org,resources=topologies,verbs=get;list;watch;update
@@ -1225,11 +1225,6 @@ func configureHorizonRbac(ctx context.Context, helper *helper.Helper, instance *
 			ResourceNames: []string{"anyuid", "hostmount-anyuid"},
 			Resources:     []string{"securitycontextconstraints"},
 			Verbs:         []string{"use"},
-		},
-		{
-			APIGroups: []string{""},
-			Resources: []string{"pods"},
-			Verbs:     []string{"create", "get", "list", "watch", "update", "patch", "delete"},
 		},
 	}
 	return common_rbac.ReconcileRbac(ctx, helper, instance, rbacRules)


### PR DESCRIPTION
The workload rbacRules and the matching kubebuilder RBAC marker in the controller granted the workload service account full CRUD (create/delete/get/list/patch/update/watch) on core Pods, but that service account never reads or writes Pod objects directly. Remove the unused grants.

The kubebuilder RBAC marker for pods (get;list) is kept: lib-common's VerifyNetworkStatusFromAnnotation, called from this controller to verify NetworkAttachments, lists Pods using the controller-manager's own client, so the manager's ClusterRole (config/rbac/role.yaml) still needs get;list on pods. Regenerate config/rbac/role.yaml.

Includes ac2eccbc8fe4eee7435ec1a4e6b4bd1b454ed55b


(cherry picked from commit 45e0ef86a1e1b8f673c730ffd72c827a43be66cc)